### PR TITLE
Фикс тайпингов для успешных и провалившихся событий.

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,4 +1,5 @@
-import bridge from './index';
+import bridge, {ExtendedWindow} from './index';
 
-// @ts-ignore
-window.vkBridge = window.vkConnect = bridge;
+const wnd = window as ExtendedWindow;
+
+wnd.vkBridge = wnd.vkConnect = bridge;

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,5 +1,4 @@
-import bridge, {ExtendedWindow} from './index';
+import bridge from './index';
 
-const wnd = window as ExtendedWindow;
-
-wnd.vkBridge = wnd.vkConnect = bridge;
+// @ts-ignore
+window.vkBridge = window.vkConnect = bridge;

--- a/src/promisifySend.ts
+++ b/src/promisifySend.ts
@@ -90,10 +90,13 @@ export function promisifySend(
       return;
     }
 
-    const { request_id: requestId, ...data } = event.detail.data;
+    // There is no request_id in method-like events, so we check its existence.
+    if ('request_id' in event.detail.data) {
+      const {request_id: requestId, ...data} = event.detail.data;
 
-    if (requestId) {
-      requestResolver.resolve(requestId, data, data => !('error_type' in data));
+      if (requestId) {
+        requestResolver.resolve(requestId, data, data => !('error_type' in data));
+      }
     }
   });
 

--- a/src/types/bridge.ts
+++ b/src/types/bridge.ts
@@ -1,8 +1,8 @@
 import {
   RequestPropsMap,
   ReceiveDataMap,
-  FailedReceiveEventMap,
-  SuccessfulReceiveEventMap,
+  ReceiveEventMap,
+  MethodLikeEventDataMap,
 } from './data';
 
 /**
@@ -16,14 +16,24 @@ export type RequestMethodName = keyof RequestPropsMap;
 export type ReceiveMethodName = keyof ReceiveDataMap;
 
 /**
+ * Name of method-like events.
+ */
+export type MethodLikeEventName = keyof MethodLikeEventDataMap;
+
+/**
  * Getter of failed event name of a method.
  */
-export type FailedReceiveEventName<M extends ReceiveMethodName> = FailedReceiveEventMap[M];
+export type FailedReceiveEventName<M extends ReceiveMethodName> = ReceiveEventMap[M]['failed'];
 
 /**
  * Getter of successful event name of a method.
  */
-export type SuccessfulReceiveEventName<M extends ReceiveMethodName> = SuccessfulReceiveEventMap[M];
+export type SuccessfulReceiveEventName<M extends ReceiveMethodName> = ReceiveEventMap[M]['result'];
+
+/**
+ * Getter of data type for method-like event.
+ */
+export type MethodLikeEventData<E extends MethodLikeEventName> = MethodLikeEventDataMap[E];
 
 /**
  * Name of a method that can be only sent.
@@ -120,34 +130,55 @@ export type ErrorData =
     };
 
 /**
- * Type of error event data
+ * Generic event type for creating event types.
  */
-export type VKBridgeErrorEvent<M extends ReceiveMethodName> = {
+export type VKBridgeEventBase<Type, Data> = {
   detail: {
-    type: FailedReceiveEventName<M>
-    data: ErrorData;
-  };
+    type: Type;
+    data: Data;
+  },
 };
 
 /**
- * Type of success event data
+ * Type of error event data.
  */
-export type VKBridgeSuccessEvent<M extends ReceiveMethodName> = {
-  detail: {
-    type: SuccessfulReceiveEventName<M>;
-    data: ReceiveData<M> & RequestIdProp;
-  };
-};
+export type VKBridgeErrorEvent<M extends ReceiveMethodName = ReceiveMethodName> = {
+  [Method in M]: VKBridgeEventBase<FailedReceiveEventName<Method>, ErrorData>
+}[M];
+
+/**
+ * Type of success event data.
+ */
+export type VKBridgeSuccessEvent<M extends ReceiveMethodName = ReceiveMethodName> = {
+  [Method in M]: SuccessfulReceiveEventName<Method> extends never
+    ? never
+    : VKBridgeEventBase<SuccessfulReceiveEventName<Method>, ReceiveData<Method> & RequestIdProp>
+}[M];
+
+/**
+ * VK Bridge usual event.
+ */
+export type VKBridgeMethodLikeEvent<M extends MethodLikeEventName = MethodLikeEventName> = {
+  [Method in M]: VKBridgeEventBase<Method, MethodLikeEventData<Method>>
+}[M];
+
+
+/**
+ * VK Bridge event describing a result of some executed method.
+ */
+export type VKBridgeResultEvent<M extends ReceiveMethodName = ReceiveMethodName> =
+  VKBridgeErrorEvent<M> |
+  VKBridgeSuccessEvent<M>;
 
 /**
  * VK Bridge event.
  */
-export type VKBridgeEvent<M extends ReceiveMethodName> = VKBridgeErrorEvent<M> | VKBridgeSuccessEvent<M>;
+export type VKBridgeEvent = VKBridgeResultEvent | VKBridgeMethodLikeEvent;
 
 /**
  * Type of function that will be subscribed to VK Bridge events.
  */
-export type VKBridgeSubscribeHandler = (event: VKBridgeEvent<ReceiveMethodName>) => void;
+export type VKBridgeSubscribeHandler = (event: VKBridgeEvent) => void;
 
 /**
  * Type of send function for methods that have props.
@@ -211,4 +242,12 @@ export interface VKBridge {
    * @returns Result of checking.
    */
   isWebView: () => boolean;
+}
+
+/**
+ * Extends window with additional bridge properties.
+ */
+export type ExtendedWindow = typeof window & {
+  vkBridge: VKBridge;
+  vkConnect: VKBridge;
 }

--- a/src/types/bridge.ts
+++ b/src/types/bridge.ts
@@ -36,6 +36,11 @@ export type SuccessfulReceiveEventName<M extends ReceiveMethodName> = ReceiveEve
 export type MethodLikeEventData<E extends MethodLikeEventName> = MethodLikeEventDataMap[E];
 
 /**
+ * Name of a method that could be observed via subscribe method.
+ */
+export type ObservableEvent = ReceiveMethodName | MethodLikeEventName;
+
+/**
  * Name of a method that can be only sent.
  */
 export type RequestOnlyMethodName = Exclude<RequestMethodName, ReceiveMethodName>;
@@ -173,7 +178,11 @@ export type VKBridgeResultEvent<M extends ReceiveMethodName = ReceiveMethodName>
 /**
  * VK Bridge event.
  */
-export type VKBridgeEvent = VKBridgeResultEvent | VKBridgeMethodLikeEvent;
+export type VKBridgeEvent<E extends ObservableEvent = ObservableEvent> = {
+  [K in E]: K extends MethodLikeEventName
+    ? VKBridgeMethodLikeEvent<K>
+    : (K extends ReceiveMethodName ? VKBridgeResultEvent<K> : never);
+}[E];
 
 /**
  * Type of function that will be subscribed to VK Bridge events.

--- a/src/types/bridge.ts
+++ b/src/types/bridge.ts
@@ -243,11 +243,3 @@ export interface VKBridge {
    */
   isWebView: () => boolean;
 }
-
-/**
- * Extends window with additional bridge properties.
- */
-export type ExtendedWindow = typeof window & {
-  vkBridge: VKBridge;
-  vkConnect: VKBridge;
-}

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -788,10 +788,6 @@ export type ReceiveDataMap = {
   VKWebAppAudioUnpaused: { type: string; id: string };
   VKWebAppInitAds: { init: 'true' | 'false' };
   VKWebAppLoadAds: { load: 'true' | 'false' };
-  VKWebAppUpdateConfig: UpdateConfigData;
-  VKWebAppUpdateInsets: { insets: Insets };
-  VKWebAppViewHide: {}; // Always empty
-  VKWebAppViewRestore: {}; // Always empty
   VKWebAppDisableSwipeBack: {};
   VKWebAppEnableSwipeBack: {};
   VKWebAppShowStoryBox: { result: true };
@@ -803,145 +799,87 @@ export type ReceiveDataMap = {
 };
 
 /**
- * Map of successful event names with methods.
+ * Successful and failed event names of executable event.
  */
-export type SuccessfulReceiveEventMap = {
-  VKWebAppAddToCommunity: 'VKWebAppAddToCommunityResult';
-  VKWebAppAllowMessagesFromGroup: 'VKWebAppAllowMessagesFromGroupResult';
-  VKWebAppAllowNotifications: 'VKWebAppAllowNotificationsResult';
-  VKWebAppCallAPIMethod: 'VKWebAppAllowNotificationsResult';
-  VKWebAppCopyText: 'VKWebAppCopyTextResult';
-  VKWebAppGetAuthToken: 'VKWebAppGetAuthTokenResult';
-  VKWebAppClose: 'VKWebAppCloseResult';
-  VKWebAppOpenApp: 'VKWebAppOpenAppResult';
-  VKWebAppDenyNotifications: 'VKWebAppDenyNotificationsResult';
-  VKWebAppFlashGetInfo: 'VKWebAppFlashGetInfoResult';
-  VKWebAppFlashSetLevel: 'VKWebAppFlashSetLevelResult';
-  VKWebAppGetClientVersion: 'VKWebAppGetClientVersionResult';
-  VKWebAppGetEmail: 'VKWebAppGetEmailResult';
-  VKWebAppGetFriends: 'VKWebAppGetFriendsResult';
-  VKWebAppGetGeodata: 'VKWebAppGetGeodataResult';
-  VKWebAppGetPersonalCard: 'VKWebAppGetPersonalCardResult';
-  VKWebAppGetPhoneNumber: 'VKWebAppGetPhoneNumberResult';
-  VKWebAppGetUserInfo: 'VKWebAppGetUserInfoResult';
-  VKWebAppJoinGroup: 'VKWebAppJoinGroupResult';
-  VKWebAppOpenCodeReader: 'VKWebAppOpenCodeReaderResult';
-  VKWebAppOpenQR: 'VKWebAppOpenQRResult';
-  VKWebAppOpenContacts: 'VKWebAppOpenContactsResult';
-  VKWebAppOpenPayForm: 'VKWebAppOpenPayFormResult';
-  VKWebAppResizeWindow: 'VKWebAppResizeWindowResult';
-  VKWebAppScroll: 'VKWebAppScrollResult';
-  VKWebAppSetLocation: 'VKWebAppSetLocationResult';
-  VKWebAppSetViewSettings: 'VKWebAppSetViewSettingsResult';
-  VKWebAppShare: 'VKWebAppShareResult';
-  VKWebAppShowCommunityWidgetPreviewBox: 'VKWebAppShowCommunityWidgetPreviewBoxResult';
-  VKWebAppShowImages: 'VKWebAppShowImagesResult';
-  VKWebAppShowInviteBox: 'VKWebAppShowInviteBoxResult';
-  VKWebAppShowLeaderBoardBox: 'VKWebAppShowLeaderBoardBoxResult';
-  VKWebAppShowMessageBox: 'VKWebAppShowMessageBoxResult';
-  VKWebAppShowOrderBox: 'VKWebAppShowOrderBoxResult';
-  VKWebAppShowRequestBox: 'VKWebAppShowRequestBoxResult';
-  VKWebAppShowWallPostBox: 'VKWebAppShowWallPostBoxResult';
-  VKWebAppStorageGet: 'VKWebAppStorageGetResult';
-  VKWebAppStorageGetKeys: 'VKWebAppStorageGetKeysResult';
-  VKWebAppStorageSet: 'VKWebAppStorageSetResult';
-  VKWebAppTapticImpactOccurred: 'VKWebAppTapticImpactOccurredResult';
-  VKWebAppTapticNotificationOccurred: 'VKWebAppTapticNotificationOccurredResult';
-  VKWebAppTapticSelectionChanged: 'VKWebAppTapticSelectionChangedResult';
-  VKWebAppAddToFavorites: 'VKWebAppAddToFavoritesResult';
-  VKWebAppSendPayload: 'VKWebAppSendPayloadResult';
-  VKWebAppGetCommunityToken: 'VKWebAppGetCommunityTokenResult';
-  VKWebAppGetCommunityAuthToken: 'VKWebAppGetCommunityAuthTokenResult';
-  VKWebAppCommunityAccessToken: 'VKWebAppCommunityAccessTokenResult';
-  VKWebAppCommunityToken: 'VKWebAppCommunityTokenResult';
-  VKWebAppAudioPaused: 'VKWebAppAudioPausedResult';
-  VKWebAppAudioStopped: 'VKWebAppAudioStoppedResult';
-  VKWebAppAudioTrackChanged: 'VKWebAppAudioTrackChangedResult';
-  VKWebAppAudioUnpaused: 'VKWebAppAudioUnpausedResult';
-  VKWebAppInitAds: 'VKWebAppInitAdsResult';
-  VKWebAppLoadAds: 'VKWebAppLoadAdsResult';
-  VKWebAppUpdateConfig: 'VKWebAppUpdateConfigResult';
-  VKWebAppUpdateInsets: 'VKWebAppUpdateInsetsResult';
-  VKWebAppViewHide: 'VKWebAppViewHideResult';
-  VKWebAppViewRestore: 'VKWebAppViewRestoreResult';
-  VKWebAppDisableSwipeBack: 'VKWebAppDisableSwipeBackResult';
-  VKWebAppEnableSwipeBack: 'VKWebAppEnableSwipeBackResult';
-  VKWebAppShowStoryBox: 'VKWebAppShowStoryBoxResult';
-  VKWebAppAccelerometerChanged: 'VKWebAppAccelerometerChangedResult';
-  VKWebAppGyroscopeChanged: 'VKWebAppGyroscopeChangedResult';
-  VKWebAppDeviceMotionChanged: 'VKWebAppDeviceMotionChangedResult';
-  VKWebAppLocationChanged: 'VKWebAppLocationChangedResult';
-  VKWebAppSubscribeStoryApp: 'VKWebAppSubscribeStoryAppResult';
+export type ReceiveEventNames<R extends string, F extends string> = {
+  result: R;
+  failed: F;
 };
 
 /**
- * Map of failed event names with methods.
+ * Successful and failed event names for method.
  */
-export type FailedReceiveEventMap = {
-  VKWebAppAddToCommunity: 'VKWebAppAddToCommunityFailed';
-  VKWebAppAllowMessagesFromGroup: 'VKWebAppAllowMessagesFromGroupFailed';
-  VKWebAppAllowNotifications: 'VKWebAppAllowNotificationsFailed';
-  VKWebAppCallAPIMethod: 'VKWebAppAllowNotificationsFailed';
-  VKWebAppCopyText: 'VKWebAppCopyTextFailed';
-  VKWebAppGetAuthToken: 'VKWebAppGetAuthTokenFailed';
-  VKWebAppClose: 'VKWebAppCloseFailed';
-  VKWebAppOpenApp: 'VKWebAppOpenAppFailed';
-  VKWebAppDenyNotifications: 'VKWebAppDenyNotificationsFailed';
-  VKWebAppFlashGetInfo: 'VKWebAppFlashGetInfoFailed';
-  VKWebAppFlashSetLevel: 'VKWebAppFlashSetLevelFailed';
-  VKWebAppGetClientVersion: 'VKWebAppGetClientVersionFailed';
-  VKWebAppGetEmail: 'VKWebAppGetEmailFailed';
-  VKWebAppGetFriends: 'VKWebAppGetFriendsFailed';
-  VKWebAppGetGeodata: 'VKWebAppGetGeodataFailed';
-  VKWebAppGetPersonalCard: 'VKWebAppGetPersonalCardFailed';
-  VKWebAppGetPhoneNumber: 'VKWebAppGetPhoneNumberFailed';
-  VKWebAppGetUserInfo: 'VKWebAppGetUserInfoFailed';
-  VKWebAppJoinGroup: 'VKWebAppJoinGroupFailed';
-  VKWebAppOpenCodeReader: 'VKWebAppOpenCodeReaderFailed';
-  VKWebAppOpenQR: 'VKWebAppOpenQRFailed';
-  VKWebAppOpenContacts: 'VKWebAppOpenContactsFailed';
-  VKWebAppOpenPayForm: 'VKWebAppOpenPayFormFailed';
-  VKWebAppResizeWindow: 'VKWebAppResizeWindowFailed';
-  VKWebAppScroll: 'VKWebAppScrollFailed';
-  VKWebAppSetLocation: 'VKWebAppSetLocationFailed';
-  VKWebAppSetViewSettings: 'VKWebAppSetViewSettingsFailed';
-  VKWebAppShare: 'VKWebAppShareFailed';
-  VKWebAppShowCommunityWidgetPreviewBox: 'VKWebAppShowCommunityWidgetPreviewBoxFailed';
-  VKWebAppShowImages: 'VKWebAppShowImagesFailed';
-  VKWebAppShowInviteBox: 'VKWebAppShowInviteBoxFailed';
-  VKWebAppShowLeaderBoardBox: 'VKWebAppShowLeaderBoardBoxFailed';
-  VKWebAppShowMessageBox: 'VKWebAppShowMessageBoxFailed';
-  VKWebAppShowOrderBox: 'VKWebAppShowOrderBoxFailed';
-  VKWebAppShowRequestBox: 'VKWebAppShowRequestBoxFailed';
-  VKWebAppShowWallPostBox: 'VKWebAppShowWallPostBoxFailed';
-  VKWebAppStorageGet: 'VKWebAppStorageGetFailed';
-  VKWebAppStorageGetKeys: 'VKWebAppStorageGetKeysFailed';
-  VKWebAppStorageSet: 'VKWebAppStorageSetFailed';
-  VKWebAppTapticImpactOccurred: 'VKWebAppTapticImpactOccurredFailed';
-  VKWebAppTapticNotificationOccurred: 'VKWebAppTapticNotificationOccurredFailed';
-  VKWebAppTapticSelectionChanged: 'VKWebAppTapticSelectionChangedFailed';
-  VKWebAppAddToFavorites: 'VKWebAppAddToFavoritesFailed';
-  VKWebAppSendPayload: 'VKWebAppSendPayloadFailed';
-  VKWebAppGetCommunityToken: 'VKWebAppGetCommunityTokenFailed';
-  VKWebAppGetCommunityAuthToken: 'VKWebAppGetCommunityAuthTokenFailed';
-  VKWebAppCommunityAccessToken: 'VKWebAppCommunityAccessTokenFailed';
-  VKWebAppCommunityToken: 'VKWebAppCommunityTokenFailed';
-  VKWebAppAudioPaused: 'VKWebAppAudioPausedFailed';
-  VKWebAppAudioStopped: 'VKWebAppAudioStoppedFailed';
-  VKWebAppAudioTrackChanged: 'VKWebAppAudioTrackChangedFailed';
-  VKWebAppAudioUnpaused: 'VKWebAppAudioUnpausedFailed';
-  VKWebAppInitAds: 'VKWebAppInitAdsFailed';
-  VKWebAppLoadAds: 'VKWebAppLoadAdsFailed';
-  VKWebAppUpdateConfig: 'VKWebAppUpdateConfigFailed';
-  VKWebAppUpdateInsets: 'VKWebAppUpdateInsetsFailed';
-  VKWebAppViewHide: 'VKWebAppViewHideFailed';
-  VKWebAppViewRestore: 'VKWebAppViewRestoreFailed';
-  VKWebAppDisableSwipeBack: 'VKWebAppDisableSwipeBackFailed';
-  VKWebAppEnableSwipeBack: 'VKWebAppEnableSwipeBackFailed';
-  VKWebAppShowStoryBox: 'VKWebAppShowStoryBoxFailed';
-  VKWebAppAccelerometerChanged: 'VKWebAppAccelerometerChangedFailed';
-  VKWebAppGyroscopeChanged: 'VKWebAppGyroscopeChangedFailed';
-  VKWebAppDeviceMotionChanged: 'VKWebAppDeviceMotionChangedFailed';
-  VKWebAppLocationChanged: 'VKWebAppLocationChangedFailed';
-  VKWebAppSubscribeStoryApp: 'VKWebAppSubscribeStoryAppFailed';
+export type ReceiveEventMap = {
+  VKWebAppAddToCommunity: ReceiveEventNames<'VKWebAppAddToCommunityResult', 'VKWebAppAddToCommunityFailed'>;
+  VKWebAppAllowMessagesFromGroup: ReceiveEventNames<'VKWebAppAllowMessagesFromGroupResult', 'VKWebAppAllowMessagesFromGroupFailed'>;
+  VKWebAppAllowNotifications: ReceiveEventNames<'VKWebAppAllowNotificationsResult', 'VKWebAppAllowNotificationsFailed'>;
+  VKWebAppCallAPIMethod: ReceiveEventNames<'VKWebAppCallAPIMethodResult', 'VKWebAppCallAPIMethodFailed'>;
+  VKWebAppCopyText: ReceiveEventNames<'VKWebAppCopyTextResult', 'VKWebAppCopyTextFailed'>;
+  VKWebAppGetAuthToken: ReceiveEventNames<'VKWebAppGetAuthTokenResult', 'VKWebAppGetAuthTokenFailed'>;
+  VKWebAppClose: ReceiveEventNames<'VKWebAppCloseResult', 'VKWebAppCloseFailed'>;
+  VKWebAppOpenApp: ReceiveEventNames<'VKWebAppOpenAppResult', 'VKWebAppOpenAppFailed'>;
+  VKWebAppDenyNotifications: ReceiveEventNames<'VKWebAppDenyNotificationsResult', 'VKWebAppDenyNotificationsFailed'>;
+  VKWebAppFlashGetInfo: ReceiveEventNames<'VKWebAppFlashGetInfoResult', 'VKWebAppFlashGetInfoFailed'>;
+  VKWebAppFlashSetLevel: ReceiveEventNames<'VKWebAppFlashSetLevelResult', 'VKWebAppFlashSetLevelFailed'>;
+  VKWebAppGetClientVersion: ReceiveEventNames<'VKWebAppGetClientVersionResult', 'VKWebAppGetClientVersionFailed'>;
+  VKWebAppGetEmail: ReceiveEventNames<'VKWebAppGetEmailResult', 'VKWebAppGetEmailFailed'>;
+  VKWebAppGetFriends: ReceiveEventNames<'VKWebAppGetFriendsResult', 'VKWebAppGetFriendsFailed'>;
+  VKWebAppGetGeodata: ReceiveEventNames<'VKWebAppGetGeodataResult', 'VKWebAppGetGeodataFailed'>;
+  VKWebAppGetPersonalCard: ReceiveEventNames<'VKWebAppGetPersonalCardResult', 'VKWebAppGetPersonalCardFailed'>;
+  VKWebAppGetPhoneNumber: ReceiveEventNames<'VKWebAppGetPhoneNumberResult', 'VKWebAppGetPhoneNumberFailed'>;
+  VKWebAppGetUserInfo: ReceiveEventNames<'VKWebAppGetUserInfoResult', 'VKWebAppGetUserInfoFailed'>;
+  VKWebAppJoinGroup: ReceiveEventNames<'VKWebAppJoinGroupResult', 'VKWebAppJoinGroupFailed'>;
+  VKWebAppOpenCodeReader: ReceiveEventNames<'VKWebAppOpenCodeReaderResult', 'VKWebAppOpenCodeReaderFailed'>;
+  VKWebAppOpenQR: ReceiveEventNames<'VKWebAppOpenQRResult', 'VKWebAppOpenQRFailed'>;
+  VKWebAppOpenContacts: ReceiveEventNames<'VKWebAppOpenContactsResult', 'VKWebAppOpenContactsFailed'>;
+  VKWebAppOpenPayForm: ReceiveEventNames<'VKWebAppOpenPayFormResult', 'VKWebAppOpenPayFormFailed'>;
+  VKWebAppResizeWindow: ReceiveEventNames<'VKWebAppResizeWindowResult', 'VKWebAppResizeWindowFailed'>;
+  VKWebAppScroll: ReceiveEventNames<'VKWebAppScrollResult', 'VKWebAppScrollFailed'>;
+  VKWebAppSetLocation: ReceiveEventNames<'VKWebAppSetLocationResult', 'VKWebAppSetLocationFailed'>;
+  VKWebAppSetViewSettings: ReceiveEventNames<'VKWebAppSetViewSettingsResult', 'VKWebAppSetViewSettingsFailed'>;
+  VKWebAppShare: ReceiveEventNames<'VKWebAppShareResult', 'VKWebAppShareFailed'>;
+  VKWebAppShowCommunityWidgetPreviewBox: ReceiveEventNames<'VKWebAppShowCommunityWidgetPreviewBoxResult', 'VKWebAppShowCommunityWidgetPreviewBoxFailed'>;
+  VKWebAppShowImages: ReceiveEventNames<'VKWebAppShowImagesResult', 'VKWebAppShowImagesFailed'>;
+  VKWebAppShowInviteBox: ReceiveEventNames<'VKWebAppShowInviteBoxResult', 'VKWebAppShowInviteBoxFailed'>;
+  VKWebAppShowLeaderBoardBox: ReceiveEventNames<'VKWebAppShowLeaderBoardBoxResult', 'VKWebAppShowLeaderBoardBoxFailed'>;
+  VKWebAppShowMessageBox: ReceiveEventNames<'VKWebAppShowMessageBoxResult', 'VKWebAppShowMessageBoxFailed'>;
+  VKWebAppShowOrderBox: ReceiveEventNames<'VKWebAppShowOrderBoxResult', 'VKWebAppShowOrderBoxFailed'>;
+  VKWebAppShowRequestBox: ReceiveEventNames<'VKWebAppShowRequestBoxResult', 'VKWebAppShowRequestBoxFailed'>;
+  VKWebAppShowWallPostBox: ReceiveEventNames<'VKWebAppShowWallPostBoxResult', 'VKWebAppShowWallPostBoxFailed'>;
+  VKWebAppStorageGet: ReceiveEventNames<'VKWebAppStorageGetResult', 'VKWebAppStorageGetFailed'>;
+  VKWebAppStorageGetKeys: ReceiveEventNames<'VKWebAppStorageGetKeysResult', 'VKWebAppStorageGetKeysFailed'>;
+  VKWebAppStorageSet: ReceiveEventNames<'VKWebAppStorageSetResult', 'VKWebAppStorageSetFailed'>;
+  VKWebAppTapticImpactOccurred: ReceiveEventNames<never, 'VKWebAppTapticImpactOccurredFailed'>;
+  VKWebAppTapticNotificationOccurred: ReceiveEventNames<never, 'VKWebAppTapticNotificationOccurredFailed'>;
+  VKWebAppTapticSelectionChanged: ReceiveEventNames<never, 'VKWebAppTapticSelectionChangedFailed'>;
+  VKWebAppAddToFavorites: ReceiveEventNames<'VKWebAppAddToFavoritesResult', 'VKWebAppAddToFavoritesFailed'>;
+  VKWebAppSendPayload: ReceiveEventNames<'VKWebAppSendPayloadResult', 'VKWebAppSendPayloadFailed'>;
+  VKWebAppGetCommunityToken: ReceiveEventNames<'VKWebAppGetCommunityTokenResult', 'VKWebAppGetCommunityTokenFailed'>;
+  VKWebAppGetCommunityAuthToken: ReceiveEventNames<'VKWebAppGetCommunityAuthTokenResult', 'VKWebAppGetCommunityAuthTokenFailed'>;
+  VKWebAppCommunityAccessToken: ReceiveEventNames<'VKWebAppCommunityAccessTokenResult', 'VKWebAppCommunityAccessTokenFailed'>;
+  VKWebAppCommunityToken: ReceiveEventNames<'VKWebAppCommunityTokenResult', 'VKWebAppCommunityTokenFailed'>;
+  VKWebAppAudioPaused: ReceiveEventNames<'VKWebAppAudioPausedResult', 'VKWebAppAudioPausedFailed'>;
+  VKWebAppAudioStopped: ReceiveEventNames<'VKWebAppAudioStoppedResult', 'VKWebAppAudioStoppedFailed'>;
+  VKWebAppAudioTrackChanged: ReceiveEventNames<'VKWebAppAudioTrackChangedResult', 'VKWebAppAudioTrackChangedFailed'>;
+  VKWebAppAudioUnpaused: ReceiveEventNames<'VKWebAppAudioUnpausedResult', 'VKWebAppAudioUnpausedFailed'>;
+  VKWebAppInitAds: ReceiveEventNames<'VKWebAppInitAdsResult', 'VKWebAppInitAdsFailed'>;
+  VKWebAppLoadAds: ReceiveEventNames<'VKWebAppLoadAdsResult', 'VKWebAppLoadAdsFailed'>;
+  VKWebAppDisableSwipeBack: ReceiveEventNames<'VKWebAppDisableSwipeBackResult', 'VKWebAppDisableSwipeBackFailed'>;
+  VKWebAppEnableSwipeBack: ReceiveEventNames<'VKWebAppEnableSwipeBackResult', 'VKWebAppEnableSwipeBackFailed'>;
+  VKWebAppShowStoryBox: ReceiveEventNames<'VKWebAppShowStoryBoxResult', 'VKWebAppShowStoryBoxFailed'>;
+  VKWebAppAccelerometerChanged: ReceiveEventNames<'VKWebAppAccelerometerChangedResult', 'VKWebAppAccelerometerChangedFailed'>;
+  VKWebAppGyroscopeChanged: ReceiveEventNames<'VKWebAppGyroscopeChangedResult', 'VKWebAppGyroscopeChangedFailed'>;
+  VKWebAppDeviceMotionChanged: ReceiveEventNames<'VKWebAppDeviceMotionChangedResult', 'VKWebAppDeviceMotionChangedFailed'>;
+  VKWebAppLocationChanged: ReceiveEventNames<'VKWebAppLocationChangedResult', 'VKWebAppLocationChangedFailed'>;
+  VKWebAppSubscribeStoryApp: ReceiveEventNames<'VKWebAppSubscribeStoryAppResult', 'VKWebAppSubscribeStoryAppFailed'>;
+};
+
+/**
+ * Data types for method-like events.
+ */
+export type MethodLikeEventDataMap = {
+  VKWebAppUpdateConfig: UpdateConfigData;
+  VKWebAppUpdateInsets: {insets: Insets};
+  VKWebAppViewHide: {};
+  VKWebAppViewRestore: {};
 };


### PR DESCRIPTION
Вкратце о PR:
Обнаружил, что при использовании конструкции типа:

```typescript
if (event.detail.type === 'VKWebAppUpdateConfig') {
    const data = event.detail.data;
}
```

typescript не способен понять что конкретно находится в `data`:

![image](https://user-images.githubusercontent.com/34907325/75630303-5f362100-5c0b-11ea-8fa8-706796f0d354.png)

То же самое касается и провалившихся / удачных событий. Там все ещё страшнее:

![image](https://user-images.githubusercontent.com/34907325/75630334-afad7e80-5c0b-11ea-9cae-315a2e536012.png)

Всё дело в том, что запись типа:
```
export type VKBridgeSuccessEvent<M extends ReceiveMethodName> = {
  detail: {
    type: SuccessfulReceiveEventName<M>;
    data: ReceiveData<M> & RequestIdProp;
  };
};
```
отрабатывает некорректно в случае когда в `M` приходит множество `ReceiveMethodName`, то есть `'VKWebAppAddToCommunity' | 'VKWebAppAllowMessagesFromGroup' | ...`. Это именно наш случай, потому что в `VKBridgeEvent` мы передаем сразу все методы, которыми можно получать данные.

Некорректность заключается в том, что в конечном итоге `VKBridgeSuccessEvent` сводится к такому значению:

```typescript
type VKBridgeSuccessEvent = {
  detail: {
    type: 'VKWebAppAddToCommunity' | 'VKWebAppAllowMessagesFromGroup' | ...
    data: 'Union всех ReceiveData<M> & RequestIdProp'
  };
};
```

То есть тайпскрипт, по сути, корректно в коде определяет с какой структурой мы работаем, это тайпинг написан не совсем корректно. Пришлось под каждый тип события - провалившийся / удачный / method-like написать хак, который в случае перечисления нескольких методов в Generic-параметре возвращал корректный Union нужных структур а не одну структуру с мешаниной.

Вот результат изменений:

![image](https://user-images.githubusercontent.com/34907325/75630470-d6b88000-5c0c-11ea-9ba7-ab7db9ef69e7.png)

Решил уйти от 2 мапов на провалившиеся и удачные события потому что это поддерживать становится очень тяжело. Создал Generic тип который упрощает эту работу и объединил в 1 мап. Теперь если появится новый метод, не придется делать изменения сразу в 2 мапах и допускать вероятность ошибки.

P.S. В коммитах забыл указать - какие-то методы не имели `Result` событий. Они связаны в основном в Taptic Engine, Теперь это тоже везде учитывается.
