### PR TITLE
Update VKWebAppGetGeodata resolve type

### DIFF
--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -833,7 +833,7 @@ export type ReceiveDataMap = {
   VKWebAppGetClientVersion: { platform: string; version: string };
   VKWebAppGetEmail: { email: string; sign: string };
   VKWebAppGetFriends: { users: Array<{ id: number; first_name: string; last_name: string }> };
-  VKWebAppGetGeodata: { available: boolean | number; lat: string; long: string };
+  VKWebAppGetGeodata: { available: 0 } | { available: 1; lat: number; long: number };
   VKWebAppGetPersonalCard: PersonalCardData;
   VKWebAppGetPhoneNumber: { phone_number: string; sign: string; is_verified: boolean };
   VKWebAppGetUserInfo: UserInfo;


### PR DESCRIPTION
- В соответствии с документацией (https://vk.com/dev/vk_bridge_events_5?f=%D0%9F%D0%BE%D0%BB%D1%83%D1%87%D0%B5%D0%BD%D0%B8%D0%B5%20%D0%B3%D0%B5%D0%BE%D0%BF%D0%BE%D0%B7%D0%B8%D1%86%D0%B8%D0%B8), available могут принимать значения 1 или 0. При этом lat и long имеются только когда available=1.
- lat и long по факту являются типом number. Нужно обновить документацию.