### PR TITLE
fix(ci): add missed shell field to gh action cmd

### DIFF
--- a/.github/actions/publish-workflow-4-complete/action.yml
+++ b/.github/actions/publish-workflow-4-complete/action.yml
@@ -51,6 +51,7 @@ runs:
         echo npmAuthToken: "$NODE_AUTH_TOKEN" >> ./.yarnrc.yml
       env:
         NODE_AUTH_TOKEN: ${{ inputs.npm_token }}
+      shell: bash
 
     - name: Publish release of ${{ inputs.package_name }}
       run: yarn workspace ${{ inputs.package_name }} npm publish --tag ${{ inputs.npm_tag }}


### PR DESCRIPTION
Забыл указать обязательное поле `shell: bash` в `.github/actions/publish-workflow-4-complete/action.yml` 🥲 

<img width="320" src="https://github.com/VKCOM/vk-bridge/assets/5850354/012e06bb-3456-4e1a-81dc-4b63f04cf226" />

---

- caused by #366 