### PR TITLE
fix(ci): setup yarnrc for publish with correct way

### DIFF
--- a/.github/actions/publish-workflow-1-setup/action.yml
+++ b/.github/actions/publish-workflow-1-setup/action.yml
@@ -9,8 +9,6 @@ runs:
       with:
         node-version: 18
         cache: 'yarn'
-        always-auth: true
-        registry-url: 'https://registry.npmjs.org'
 
     - name: Install dependencies
       run: YARN_ENABLE_SCRIPTS=false yarn install

--- a/.github/actions/publish-workflow-4-complete/action.yml
+++ b/.github/actions/publish-workflow-4-complete/action.yml
@@ -46,11 +46,12 @@ runs:
         github_token: ${{ inputs.token }}
         branch: ${{ inputs.branch }}
 
-    - name: Prepare NPM credentials
+    - name: Setup NPM Auth Token to .yarnrc.yml
       run: |
-        echo npmAuthToken: "$NODE_AUTH_TOKEN" >> ./.yarnrc.yml
+        yarn config set npmAlwaysAuth true
+        yarn config set npmAuthToken $NPM_AUTH_TOKEN
       env:
-        NODE_AUTH_TOKEN: ${{ inputs.npm_token }}
+        NPM_AUTH_TOKEN: ${{ inputs.npm_token }}
       shell: bash
 
     - name: Publish release of ${{ inputs.package_name }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -35,3 +35,5 @@ coverage
 
 # Yarn
 .yarn/*
+## yarn itself formats the file
+.yarnrc.yml

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,7 +1,11 @@
 nodeLinker: node-modules
 
+npmPublishAccess: public
+
+npmRegistryServer: "https://registry.npmjs.org"
+
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-workspace-tools.cjs
-    spec: '@yarnpkg/plugin-workspace-tools'
+    spec: "@yarnpkg/plugin-workspace-tools"
 
 yarnPath: .yarn/releases/yarn-3.6.0.cjs


### PR DESCRIPTION
`yarn >= 2` ignore `.npmrc` and that is why we:

- set `npmRegistryServer` (default is "https://registry.yarnpkg.com/")
  see https://yarnpkg.com/configuration/yarnrc#npmRegistryServer
- set `npmAlwaysAuth`
  
---

- caused by #366 