### PR TITLE
bump(@vkontakte/vk-bridge): from 2.7.5 to 2.8.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vkontakte/vk-bridge",
-  "version": "2.7.5",
+  "version": "2.8.0",
   "description": "Connects a Mini App with VK client",
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
https://www.npmjs.com/package/@vkontakte/vk-bridge/v/2.8.0

> **Note**
>  
> Тэг, который создаётся в CI
> https://github.com/VKCOM/vk-bridge/blob/5fcd9f7dac1481ce47c09a49721dc300096e2ffc/.github/actions/publish-workflow-4-complete/action.yml#L40
> пришлось создать вручную ([@vkontakte/vk-bridge@2.8.0](https://github.com/VKCOM/vk-bridge/releases/tag/%40vkontakte%2Fvk-bridge%402.8.0)), так как он не запушился.
>
> Необходимо передать параметр `tags` в экшен пуша
> https://github.com/VKCOM/vk-bridge/blob/5fcd9f7dac1481ce47c09a49721dc300096e2ffc/.github/actions/publish-workflow-4-complete/action.yml#L43-L47
> Сделаю отдельным PR.