### PR TITLE
fix(ci): use tags flag for push action

### DIFF
--- a/.github/actions/publish-workflow-4-complete/action.yml
+++ b/.github/actions/publish-workflow-4-complete/action.yml
@@ -45,6 +45,7 @@ runs:
       with:
         github_token: ${{ inputs.token }}
         branch: ${{ inputs.branch }}
+        tags: true
 
     - name: Setup NPM Auth Token to .yarnrc.yml
       run: |


### PR DESCRIPTION
В рамках https://github.com/VKCOM/vk-bridge/pull/369, обнаружил, что не пушится `git tag` (см. описание #369).

---

- caused by #360