### PR TITLE
fix: return missed build for ts3.8.3

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
   ],
   "scripts": {
     "watch": "yarn run --top-level rollup -c -w",
-    "build": "NODE_ENV=production yarn run --top-level rollup -c",
+    "build": "NODE_ENV=production yarn run --top-level rollup -c && yarn run build:legacy-types",
     "build:legacy-types": "yarn run --top-level rollup -c rollup.config-legacy-types.mjs >/dev/null",
     "prepack": "yarn run build"
   },


### PR DESCRIPTION
build:legacy-types was remove in #360

---

- caused by #360