### PR TITLE
refactor(@vkontakte/vk-bridge-react): changes after v1.0.0-beta.0 test

### DIFF
--- a/packages/react/src/functions/runTapticImpactOccurred.ts
+++ b/packages/react/src/functions/runTapticImpactOccurred.ts
@@ -1,8 +1,15 @@
 import vkBridge from '@vkontakte/vk-bridge';
 import type { TapticVibrationPowerType } from '@vkontakte/vk-bridge';
 
+/**
+ * Dispatch device vibration if supported.
+ *
+ * Return `false` if not supported.
+ */
 export function runTapticImpactOccurred(style: TapticVibrationPowerType) {
   if (vkBridge.supports('VKWebAppTapticImpactOccurred')) {
     vkBridge.send('VKWebAppTapticImpactOccurred', { style }).catch(() => undefined);
+    return true;
   }
+  return false;
 }

--- a/packages/react/src/hooks/useInsets.ts
+++ b/packages/react/src/hooks/useInsets.ts
@@ -8,21 +8,14 @@ const VIRTUAL_KEYBOARD_HEIGHT = 150;
 const BOTTOM_INSET_FOR_VIRTUAL_KEYBOARD = 0;
 
 export interface UseInsets {
-  top: Insets['top'] | null;
-  right: Insets['right'] | null;
-  bottom: Insets['bottom'] | null;
-  left: Insets['left'] | null;
+  top: Insets['top'];
+  right: Insets['right'];
+  bottom: Insets['bottom'];
+  left: Insets['left'];
 }
 
-let initialState: UseInsets = {
-  bottom: null,
-  top: null,
-  left: null,
-  right: null,
-};
-
-export const useInsets = (): UseInsets => {
-  const [insets, setInsets] = useState<UseInsets>(initialState);
+export const useInsets = (): UseInsets | null => {
+  const [insets, setInsets] = useState<UseInsets | null>(null);
 
   useIsomorphicLayoutEffect(() => {
     const handleBridgeEvent = (event: VKBridgeEvent<AnyReceiveMethodName>) => {


### PR DESCRIPTION
Тест [v1.0.0-beta.0](https://www.npmjs.com/package/@vkontakte/vk-bridge-react/v/1.0.0-beta.0) показал, что нужны следующие изменения:

### `hooks/useInsets`

Лучше возвращать `null` при инициализации или если нет данных.

### `functions/runTapticImpactOccurred`

Возвращаем `boolean`, которые будет давать понять поддерживается ли вибрация или нет.