### PR TITLE
fix(useInsets): fix types

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -83,12 +83,12 @@ const App = () => {
 
 <!-- prettier-ignore -->
   ```ts
-  interface UseInsets {
-    top: number | null;
-    right: number | null;
-    bottom: number | null;
-    left: number | null;
-  }
+  type UseInsets = {
+    top: number;
+    right: number;
+    bottom: number;
+    left: number;
+  } | null;
   ```
 
   </td>

--- a/packages/react/src/hooks/useInsets.ts
+++ b/packages/react/src/hooks/useInsets.ts
@@ -7,15 +7,15 @@ const VIRTUAL_KEYBOARD_HEIGHT = 150;
 
 const BOTTOM_INSET_FOR_VIRTUAL_KEYBOARD = 0;
 
-export interface UseInsets {
+export type UseInsets = {
   top: Insets['top'];
   right: Insets['right'];
   bottom: Insets['bottom'];
   left: Insets['left'];
-}
+} | null;
 
-export const useInsets = (): UseInsets | null => {
-  const [insets, setInsets] = useState<UseInsets | null>(null);
+export const useInsets = (): UseInsets => {
+  const [insets, setInsets] = useState<UseInsets>(null);
 
   useIsomorphicLayoutEffect(() => {
     const handleBridgeEvent = (event: VKBridgeEvent<AnyReceiveMethodName>) => {


### PR DESCRIPTION
- Забыл поправить доку.
- Заодно поправил тип `UseInsets`, что возвращает `null`.

---

- caused by #408