### PR TITLE
fix(vk-bridge-react): fix path to types in dist

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.es.js",
-  "types": "dist/types/src/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Был указан неправильный путь до типов в `dist`.

---

- caused by #382