### PR TITLE
bump(@vkontakte/vk-bridge): from 2.8.3 to 2.9.0

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -173,3 +173,28 @@ const logger =
 
 const enhancedBridge = applyMiddleware(logger)(bridge);
 ```
+
+## Functions
+
+### `parseURLSearchParamsForGetLaunchParams(urlSearchParams: string)`
+
+Parse URL search params for get provided to mini app [launch params](https://dev.vk.com/mini-apps/development/launch-params).
+
+**Parameters**
+
+- `urlSearchParams` a.k.a `window.location.search`.
+
+**Example**
+
+```js
+import { parseURLSearchParamsForGetLaunchParams } from '@vkontakte/vk-bridge';
+
+// https://exmample-mini-app.io/?vk_platform=desktop_web&vk_is_app_user=1&vk_user_id=12345
+const { vk_platform, vk_viewer_group_role, vk_user_id } = parseURLSearchParamsForGetLaunchParams(
+  window.location.search,
+);
+
+console.log(vk_platform); // 'desktop_web'
+console.log(vk_is_app_user); // 1
+console.log(vk_user_id); // 12345
+```

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vkontakte/vk-bridge",
-  "version": "2.8.3",
+  "version": "2.9.0",
   "description": "Connects a Mini App with VK client",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,8 @@
     "watch": "yarn run --top-level rollup -c -w",
     "build": "NODE_ENV=production yarn run --top-level rollup -c && yarn run build:legacy-types",
     "build:legacy-types": "yarn run --top-level rollup -c rollup.config-legacy-types.mjs >/dev/null",
-    "prepack": "yarn run build"
+    "prepack": "yarn run build",
+    "test": "yarn run --top-level jest --config ../../jest.config.js"
   },
   "author": {
     "name": "VK",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,4 +11,7 @@ export * from './types/middleware';
 export * from './types/deprecated';
 
 export { applyMiddleware } from './applyMiddleware';
+
+export { parseURLSearchParamsForGetLaunchParams } from './parseURLSearchParamsForGetLaunchParams';
+
 export { bridge as default };

--- a/packages/core/src/parseSearchParamsForGetLaunchParams.test.ts
+++ b/packages/core/src/parseSearchParamsForGetLaunchParams.test.ts
@@ -1,0 +1,103 @@
+import { parseURLSearchParamsForGetLaunchParams } from './parseURLSearchParamsForGetLaunchParams';
+
+describe('parseLaunchParamsByURL', () => {
+  it('should return the vk_language field if it valid', () => {
+    expect(parseURLSearchParamsForGetLaunchParams('vk_language=ru')).toEqual({
+      vk_language: 'ru',
+    });
+    expect(parseURLSearchParamsForGetLaunchParams('vk_language=unknown')).toEqual({
+      vk_language: undefined,
+    });
+  });
+
+  it('should return the vk_viewer_group_role field if it valid', () => {
+    expect(parseURLSearchParamsForGetLaunchParams('vk_viewer_group_role=admin')).toEqual({
+      vk_viewer_group_role: 'admin',
+    });
+    expect(parseURLSearchParamsForGetLaunchParams('vk_viewer_group_role=unknown')).toEqual({
+      vk_viewer_group_role: undefined,
+    });
+  });
+
+  it('should return the vk_platform field if it valid', () => {
+    expect(parseURLSearchParamsForGetLaunchParams('vk_platform=desktop_web')).toEqual({
+      vk_platform: 'desktop_web',
+    });
+    expect(parseURLSearchParamsForGetLaunchParams('vk_platform=unknown')).toEqual({
+      vk_platform: undefined,
+    });
+  });
+
+  it('should return converted toggle state from string to number if it valid', () => {
+    expect(
+      parseURLSearchParamsForGetLaunchParams(
+        'vk_is_app_user=0&vk_are_notifications_enabled=0&vk_is_favorite=0',
+      ),
+    ).toEqual({
+      vk_is_app_user: 0,
+      vk_are_notifications_enabled: 0,
+      vk_is_favorite: 0,
+    });
+    expect(
+      parseURLSearchParamsForGetLaunchParams(
+        'vk_is_app_user=1&vk_are_notifications_enabled=1&vk_is_favorite=1',
+      ),
+    ).toEqual({
+      vk_is_app_user: 1,
+      vk_are_notifications_enabled: 1,
+      vk_is_favorite: 1,
+    });
+    expect(
+      parseURLSearchParamsForGetLaunchParams(
+        'vk_is_app_user=3&vk_are_notifications_enabled=3&vk_is_favorite=3',
+      ),
+    ).toEqual({
+      vk_is_app_user: undefined,
+      vk_are_notifications_enabled: undefined,
+      vk_is_favorite: undefined,
+    });
+  });
+
+  it('should return converted to number value', () => {
+    expect(
+      parseURLSearchParamsForGetLaunchParams(
+        'vk_ts=123&vk_is_recommended=456&vk_profile_id=789&vk_has_profile_button=101&vk_testing_group_id=102&vk_user_id=103&vk_app_id=104&vk_group_id=105',
+      ),
+    ).toEqual({
+      vk_ts: 123,
+      vk_is_recommended: 456,
+      vk_profile_id: 789,
+      vk_has_profile_button: 101,
+      vk_testing_group_id: 102,
+      vk_user_id: 103,
+      vk_app_id: 104,
+      vk_group_id: 105,
+    });
+  });
+
+  it('should return value as is', () => {
+    expect(
+      parseURLSearchParamsForGetLaunchParams(
+        'sign=some_sign123&vk_chat_id=some_vk_chat_id123&vk_ref=some_vk_ref123&vk_access_token_settings=some_vk_access_token_settings123',
+      ),
+    ).toEqual({
+      sign: 'some_sign123',
+      vk_chat_id: 'some_vk_chat_id123',
+      vk_ref: 'some_vk_ref123',
+      vk_access_token_settings: 'some_vk_access_token_settings123',
+    });
+  });
+
+  // see https://dev.vk.com/mini-apps/development/launch-params?vk_are_notifications_enabled=1#odr_enabled
+  it('should return 1 or undefined', () => {
+    expect(parseURLSearchParamsForGetLaunchParams('odr_enabled=1')).toEqual({
+      odr_enabled: 1,
+    });
+    expect(parseURLSearchParamsForGetLaunchParams('odr_enabled=0')).toEqual({
+      odr_enabled: undefined,
+    });
+    expect(parseURLSearchParamsForGetLaunchParams('odr_enabled=unknown')).toEqual({
+      odr_enabled: undefined,
+    });
+  });
+});

--- a/packages/core/src/parseURLSearchParamsForGetLaunchParams.ts
+++ b/packages/core/src/parseURLSearchParamsForGetLaunchParams.ts
@@ -25,7 +25,7 @@ export const parseURLSearchParamsForGetLaunchParams = (
   try {
     const parsedSearchParams = new URLSearchParams(searchParams);
 
-    const covertToggleStateFromStringToNumber = (value: string) => {
+    const convertToggleStateFromStringToNumber = (value: string) => {
       switch (value) {
         case '0':
           return 0;
@@ -60,7 +60,7 @@ export const parseURLSearchParamsForGetLaunchParams = (
         case 'vk_is_app_user':
         case 'vk_are_notifications_enabled':
         case 'vk_is_favorite': {
-          launchParams[query] = covertToggleStateFromStringToNumber(value);
+          launchParams[query] = convertToggleStateFromStringToNumber(value);
           break;
         }
         case 'vk_language': {

--- a/packages/core/src/parseURLSearchParamsForGetLaunchParams.ts
+++ b/packages/core/src/parseURLSearchParamsForGetLaunchParams.ts
@@ -1,0 +1,95 @@
+import type { GetLaunchParamsResponse } from './types/data';
+import {
+  EGetLaunchParamsResponseLanguages,
+  EGetLaunchParamsResponseGroupRole,
+  EGetLaunchParamsResponsePlatforms,
+} from './types/data';
+
+export interface LaunchParams extends GetLaunchParamsResponse {
+  vk_chat_id: string;
+  vk_is_recommended: number;
+  vk_profile_id: number;
+  vk_has_profile_button: number;
+  vk_testing_group_id: number;
+  odr_enabled: undefined | 1;
+}
+
+/**
+ * @see https://dev.vk.com/mini-apps/development/launch-params
+ */
+export const parseURLSearchParamsForGetLaunchParams = (
+  searchParams: string,
+): Partial<LaunchParams> => {
+  const launchParams: Partial<LaunchParams> = {};
+
+  try {
+    const parsedSearchParams = new URLSearchParams(searchParams);
+
+    const covertToggleStateFromStringToNumber = (value: string) => {
+      switch (value) {
+        case '0':
+          return 0;
+        case '1':
+          return 1;
+        default:
+          return undefined;
+      }
+    };
+
+    parsedSearchParams.forEach((value, query) => {
+      switch (query) {
+        case 'vk_ts':
+        case 'vk_is_recommended':
+        case 'vk_profile_id':
+        case 'vk_has_profile_button':
+        case 'vk_testing_group_id':
+        case 'vk_user_id':
+        case 'vk_app_id':
+        case 'vk_group_id':
+          launchParams[query] = Number(value);
+          break;
+        case 'sign':
+        case 'vk_chat_id':
+        case 'vk_ref':
+        case 'vk_access_token_settings':
+          launchParams[query] = value;
+          break;
+        case 'odr_enabled':
+          launchParams['odr_enabled'] = value === '1' ? 1 : undefined;
+          break;
+        case 'vk_is_app_user':
+        case 'vk_are_notifications_enabled':
+        case 'vk_is_favorite': {
+          launchParams[query] = covertToggleStateFromStringToNumber(value);
+          break;
+        }
+        case 'vk_language': {
+          const validateVKLanguage = (value: string): value is EGetLaunchParamsResponseLanguages =>
+            Object.values(EGetLaunchParamsResponseLanguages).some((i) => i === value);
+          launchParams['vk_language'] = validateVKLanguage(value) ? value : undefined;
+          break;
+        }
+        case 'vk_viewer_group_role': {
+          const validateVKViewerGroupRole = (
+            value: string,
+          ): value is EGetLaunchParamsResponseGroupRole =>
+            Object.values(EGetLaunchParamsResponseGroupRole).some((i) => i === value);
+          launchParams['vk_viewer_group_role'] = validateVKViewerGroupRole(value)
+            ? value
+            : undefined;
+          break;
+        }
+        case 'vk_platform': {
+          const validateVKPlatform = (value: string): value is EGetLaunchParamsResponsePlatforms =>
+            Object.values(EGetLaunchParamsResponsePlatforms).some((i) => i === value);
+          launchParams['vk_platform'] = validateVKPlatform(value) ? value : undefined;
+          break;
+        }
+      }
+    });
+  } catch (e) {
+    console.warn(e);
+  }
+
+  return launchParams;
+};


### PR DESCRIPTION
## 2.9.0

- Create `parseURLSearchParamsForGetLaunchParams()`. Function returns [launch params](https://dev.vk.com/mini-apps/development/launch-params).
- Add "Translate" method typings