### PR TITLE
release: @vkontakte/vk-bridge-react 1.0.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ on:
         type: choice
         options:
           - '@vkontakte/vk-bridge'
+          - '@vkontakte/vk-bridge-react'
         required: true
       new_version:
         description: 'version type:'

--- a/.github/workflows/publish_prerelease.yml
+++ b/.github/workflows/publish_prerelease.yml
@@ -8,6 +8,7 @@ on:
         type: choice
         options:
           - '@vkontakte/vk-bridge'
+          - '@vkontakte/vk-bridge-react'
         required: true
       new_version:
         description: 'version type (use prerelease for bumping pre-release version):'

--- a/packages/react/.eslintrc.json
+++ b/packages/react/.eslintrc.json
@@ -1,0 +1,23 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "project": "./tsconfig.json"
+  },
+  "plugins": ["import", "unicorn"],
+  "extends": [
+    "plugin:@vkontakte/eslint-plugin/react-typescript", // "Preset 1"
+    "plugin:prettier/recommended" // "Preset 2"
+  ],
+  "rules": {
+    "@typescript-eslint/no-magic-numbers": "off", // [Reason] overrides "Preset 1",
+    "@typescript-eslint/no-unnecessary-condition": "off", // [Reason] overrides "Preset 1"
+    "@typescript-eslint/no-non-null-assertion": "off", // [Reason] overrides "Preset 1"
+    "@typescript-eslint/prefer-ts-expect-error": "off", // [Reason] overrides "Preset 1" (see rollup.config-legacy-types.mjs)
+    "@typescript-eslint/ban-ts-comment": "off", // [Reason] overrides "Preset 1" (see rollup.config-legacy-types.mjs)
+
+    "no-shadow": "off",
+
+    "unicorn/expiring-todo-comments": ["error"]
+  }
+}

--- a/packages/react/LICENSE
+++ b/packages/react/LICENSE
@@ -1,0 +1,25 @@
+MIT License
+
+
+Copyright (c) 2023-present, V Kontakte, LLC.
+
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -83,12 +83,12 @@ const App = () => {
 
 <!-- prettier-ignore -->
   ```ts
-  interface UseInsets {
-    top: number | null;
-    right: number | null;
-    bottom: number | null;
-    left: number | null;
-  }
+  type UseInsets = {
+    top: number;
+    right: number;
+    bottom: number;
+    left: number;
+  } | null;
   ```
 
   </td>

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,0 +1,130 @@
+# VK Bridge React
+
+React hooks for VK Bridge.
+
+In addition, the library provides other helper functions.
+
+## Usage
+
+```sh
+npm install @vkontakte/vk-bridge @vkontakte/vk-bridge-react
+```
+
+```tsx
+import { useInsets, runTapticImpactOccurred } from '@vkontakte/vk-bridge-react';
+
+// Sends event to client
+const App = () => {
+  const insets = useInsets();
+
+  const handleClick = () => {
+    runTapticImpactOccurred();
+  };
+
+  return (
+    <div style={{ paddingTop: insets?.top }}>
+      <button onClick={handleClick}>Touch to me and feel</button>
+    </div>
+  );
+};
+```
+
+## Hooks
+
+<table>
+
+<tr>
+  <td> <b>Name</b> </td>
+  <td> <b>Return type</b> </td>
+  <td> <b>Description</b> </td>
+</tr>
+
+<tr>
+  <td> <code>useAppearance()</code> </td>
+  <td>
+
+<!-- prettier-ignore -->
+  ```ts
+  type UseAppearance = AppearanceType | null;
+  ```
+
+  </td>
+  <td>
+
+<!-- prettier-ignore -->
+  Hook listens to update the `appearance` property of the `VKWebAppUpdateConfig` event. It dispatches the `VKWebAppGetConfig` event on first initialization.
+
+<!-- prettier-ignore -->
+  > **Note:** hook works only for `vkBridge.isEmbedded()` mode.
+
+  </td>
+</tr>
+
+<tr>
+  <td> <code>useAdaptivity()</code> </td>
+  <td>
+
+<!-- prettier-ignore -->
+  ```ts
+  interface UseAdaptivity {
+    type: null | AdaptivityType;
+    viewportWidth: number;
+    viewportHeight: number;
+  }
+  ```
+
+  </td>
+  <td> Hook listens to update the <code>adaptivity</code> property of the <code>VKWebAppUpdateConfig</code> event. </td>
+</tr>
+
+<tr>
+  <td> <code>useInsets()</code> </td>
+  <td>
+
+<!-- prettier-ignore -->
+  ```ts
+  interface UseInsets {
+    top: number | null;
+    right: number | null;
+    bottom: number | null;
+    left: number | null;
+  }
+  ```
+
+  </td>
+  <td>
+
+<!-- prettier-ignore -->
+  Hook listens to update the `insets` property of the `VKWebAppUpdateConfig` event.
+
+<!-- prettier-ignore -->
+  > **Note:** when the virtual keyboard is visible, _inset_ of _bottom_ corresponds to **0**.
+
+  </td>
+</tr>
+
+<tr>
+  <td> <code>runTapticImpactOccurred</code> </td>
+  <td> <code>void</code> </td>
+  <td> Function dispatches <code>VKWebAppTapticImpactOccurred</code> event if it is support. </td>
+</tr>
+
+</table>
+
+## Helpers
+
+<table>
+
+<tr>
+  <td> <b>Name</b> </td>
+  <td> <b>Return type</b> </td>
+  <td> <b>Description</b> </td>
+</tr>
+
+<tr>
+  <td> <code>runTapticImpactOccurred</code> </td>
+  <td> <code>void</code> </td>
+  <td> Function dispatches <code>VKWebAppTapticImpactOccurred</code> event if it is support. </td>
+</tr>
+
+</table>

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -23,7 +23,7 @@ const App = () => {
 
   return (
     <div style={{ paddingTop: insets?.top }}>
-      <button onClick={handleClick}>Touch to me and feel</button>
+      <button onClick={handleClick}>Touch me and feel</button>
     </div>
   );
 };
@@ -103,12 +103,6 @@ const App = () => {
   </td>
 </tr>
 
-<tr>
-  <td> <code>runTapticImpactOccurred</code> </td>
-  <td> <code>void</code> </td>
-  <td> Function dispatches <code>VKWebAppTapticImpactOccurred</code> event if it is support. </td>
-</tr>
-
 </table>
 
 ## Helpers
@@ -123,8 +117,8 @@ const App = () => {
 
 <tr>
   <td> <code>runTapticImpactOccurred</code> </td>
-  <td> <code>void</code> </td>
-  <td> Function dispatches <code>VKWebAppTapticImpactOccurred</code> event if it is support. </td>
+  <td> <code>boolean</code> </td>
+  <td> Function dispatches <code>VKWebAppTapticImpactOccurred</code> event if it is support (will return <code>true</code>). </td>
 </tr>
 
 </table>

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vkontakte/vk-bridge-react",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "description": "React hooks for VK Bridge",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@vkontakte/vk-bridge-react",
+  "version": "0.0.0",
+  "description": "React hooks for VK Bridge",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "module": "dist/index.es.js",
+  "types": "dist/types/src/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "watch": "yarn run --top-level rollup -c -w",
+    "build": "NODE_ENV=production yarn run --top-level rollup -c",
+    "prepack": "yarn run build"
+  },
+  "author": {
+    "name": "VK",
+    "url": "https://vk.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/VKCOM/vk-bridge.git",
+    "directory": "packages/react"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.13",
+    "@vkontakte/vk-bridge": "workspace:^",
+    "eslint-plugin-react": "^7.32.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "react": "^18.2.0"
+  },
+  "peerDependencies": {
+    "@types/react": "^17.0.0 || ^18.0.0",
+    "@vkontakte/vk-bridge": "workspace:^",
+    "react": "^17.0.0 || ^18.1.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  }
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.es.js",
-  "types": "dist/types/src/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "files": [
     "dist"
   ],

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vkontakte/vk-bridge-react",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "React hooks for VK Bridge",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vkontakte/vk-bridge-react",
-  "version": "0.0.0",
+  "version": "1.0.0-beta.0",
   "description": "React hooks for VK Bridge",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vkontakte/vk-bridge-react",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0",
   "description": "React hooks for VK Bridge",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vkontakte/vk-bridge-react",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "description": "React hooks for VK Bridge",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vkontakte/vk-bridge-react",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "description": "React hooks for VK Bridge",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/react/rollup.config.mjs
+++ b/packages/react/rollup.config.mjs
@@ -1,0 +1,59 @@
+import babel from '@rollup/plugin-babel';
+import nodeResolve from '@rollup/plugin-node-resolve';
+import terser from '@rollup/plugin-terser';
+import commonjs from '@rollup/plugin-commonjs';
+import typescript from 'rollup-plugin-typescript2';
+import bundleSizes from 'rollup-plugin-bundle-size';
+import json from '@rollup/plugin-json';
+import pkg from './package.json' assert { type: 'json' };
+
+const IS_PROD = process.env.NODE_ENV === 'production';
+
+const INPUT_FILE = './src/index.ts';
+
+const getPlugins = (tsDeclaration = false) => [
+  typescript(
+    tsDeclaration
+      ? {
+          useTsconfigDeclarationDir: true,
+          tsconfigOverride: {
+            compilerOptions: {
+              declaration: true,
+              declarationDir: 'dist/types',
+            },
+            exclude: ['**/dist', '**/*.test.ts'],
+          },
+        }
+      : {},
+  ),
+  babel({ babelHelpers: 'bundled' }),
+  json(),
+  nodeResolve({ mainFields: ['module', 'jsnext'] }),
+  commonjs({ include: 'node_modules/**' }),
+  bundleSizes(),
+];
+
+const cjs = {
+  plugins: IS_PROD ? [...getPlugins(true), terser()] : getPlugins(true),
+  input: INPUT_FILE,
+  output: {
+    sourcemap: true,
+    exports: 'named',
+    file: pkg.main,
+    format: 'cjs',
+  },
+  external: ['react', '@vkontakte/vk-bridge'],
+};
+
+const es = {
+  plugins: getPlugins(),
+  input: INPUT_FILE,
+  output: {
+    sourcemap: true,
+    file: pkg.module,
+    format: 'es',
+  },
+  external: ['react', '@vkontakte/vk-bridge'],
+};
+
+export default IS_PROD ? [cjs, es] : es;

--- a/packages/react/src/functions/runTapticImpactOccurred.ts
+++ b/packages/react/src/functions/runTapticImpactOccurred.ts
@@ -1,8 +1,15 @@
 import vkBridge from '@vkontakte/vk-bridge';
 import type { TapticVibrationPowerType } from '@vkontakte/vk-bridge';
 
+/**
+ * Dispatch device vibration if supported.
+ *
+ * Return `false` if not supported.
+ */
 export function runTapticImpactOccurred(style: TapticVibrationPowerType) {
   if (vkBridge.supports('VKWebAppTapticImpactOccurred')) {
     vkBridge.send('VKWebAppTapticImpactOccurred', { style }).catch(() => undefined);
+    return true;
   }
+  return false;
 }

--- a/packages/react/src/functions/runTapticImpactOccurred.ts
+++ b/packages/react/src/functions/runTapticImpactOccurred.ts
@@ -1,0 +1,8 @@
+import vkBridge from '@vkontakte/vk-bridge';
+import type { TapticVibrationPowerType } from '@vkontakte/vk-bridge';
+
+export function runTapticImpactOccurred(style: TapticVibrationPowerType) {
+  if (vkBridge.supports('VKWebAppTapticImpactOccurred')) {
+    vkBridge.send('VKWebAppTapticImpactOccurred', { style }).catch(() => undefined);
+  }
+}

--- a/packages/react/src/hooks/useAdaptivity.ts
+++ b/packages/react/src/hooks/useAdaptivity.ts
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import vkBridge from '@vkontakte/vk-bridge';
+import type {
+  VKBridgeEvent,
+  AnyReceiveMethodName,
+  AdaptivityType,
+  SharedUpdateConfigData,
+  ParentConfigData,
+} from '@vkontakte/vk-bridge';
+import { useIsomorphicLayoutEffect } from '../lib/react';
+
+export interface UseAdaptivity {
+  type: null | AdaptivityType;
+  viewportWidth: number;
+  viewportHeight: number;
+}
+
+const initialState: UseAdaptivity = {
+  type: null,
+  viewportWidth: 0,
+  viewportHeight: 0,
+};
+
+export const useAdaptivity = (): UseAdaptivity => {
+  const [bridgeAdaptivity, setBridgeAdaptivity] = useState<UseAdaptivity>(initialState);
+
+  useIsomorphicLayoutEffect(() => {
+    const updateAdaptivity = (data: ParentConfigData) => {
+      if (!('adaptivity' in data) || !('viewport_width' in data) || !('viewport_height' in data)) {
+        return;
+      }
+
+      const newAdaptivity = resolveAdaptivity(data);
+
+      if (newAdaptivity) {
+        setBridgeAdaptivity(newAdaptivity);
+      }
+    };
+
+    const handleBridgeEvent = (event: VKBridgeEvent<AnyReceiveMethodName>) => {
+      const { type, data } = event.detail;
+
+      if (type !== 'VKWebAppUpdateConfig') {
+        return;
+      }
+
+      updateAdaptivity(data);
+    };
+
+    vkBridge.subscribe(handleBridgeEvent);
+    vkBridge.send('VKWebAppGetConfig').then(updateAdaptivity).catch(console.error);
+
+    return () => {
+      vkBridge.unsubscribe(handleBridgeEvent);
+    };
+  }, []);
+
+  return bridgeAdaptivity;
+};
+
+function resolveAdaptivity(data: SharedUpdateConfigData): UseAdaptivity | null {
+  const { adaptivity, viewport_width, viewport_height } = data;
+
+  const bridgeAdaptivity: UseAdaptivity = {
+    type: null,
+    viewportWidth: isFinite(viewport_width) ? Number(viewport_width) : 0,
+    viewportHeight: isFinite(viewport_height) ? Number(viewport_height) : 0,
+  };
+
+  switch (adaptivity) {
+    case 'force_mobile':
+    case 'force_mobile_compact':
+    case 'adaptive':
+      bridgeAdaptivity.type = adaptivity;
+  }
+
+  return bridgeAdaptivity;
+}

--- a/packages/react/src/hooks/useApperance.ts
+++ b/packages/react/src/hooks/useApperance.ts
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import vkBridge from '@vkontakte/vk-bridge';
+import type {
+  AnyReceiveMethodName,
+  VKBridgeEvent,
+  AppearanceType,
+  ParentConfigData,
+} from '@vkontakte/vk-bridge';
+import { useIsomorphicLayoutEffect } from '../lib/react';
+
+export type UseAppearance = AppearanceType | null;
+
+/**
+ * Note: it works only for "embedded" app mode.
+ */
+export const useAppearance = (): UseAppearance => {
+  const [appearance, setAppearance] = useState<UseAppearance>(null);
+
+  useIsomorphicLayoutEffect(() => {
+    if (!vkBridge.isEmbedded()) {
+      return;
+    }
+
+    const updateAppearance = (data: ParentConfigData) => {
+      const initialAppearance = resolveAppearance(data);
+
+      if (initialAppearance) {
+        setAppearance(initialAppearance);
+      }
+    };
+
+    const handleBridgeEvent = (event: VKBridgeEvent<AnyReceiveMethodName>) => {
+      const { type, data } = event.detail;
+
+      if (type !== 'VKWebAppUpdateConfig' || !('appearance' in data) || !('scheme' in data)) {
+        return;
+      }
+
+      updateAppearance(data);
+    };
+
+    vkBridge.subscribe(handleBridgeEvent);
+    vkBridge.send('VKWebAppGetConfig').then(updateAppearance).catch(console.error);
+
+    return () => vkBridge.unsubscribe(handleBridgeEvent);
+  }, []);
+
+  return appearance;
+};
+
+function resolveAppearance({ scheme, appearance }: ParentConfigData): UseAppearance {
+  if (appearance) {
+    return appearance;
+  }
+
+  return scheme === 'space_gray' || scheme === 'vkcom_dark' ? 'dark' : 'light';
+}

--- a/packages/react/src/hooks/useInsets.ts
+++ b/packages/react/src/hooks/useInsets.ts
@@ -7,15 +7,15 @@ const VIRTUAL_KEYBOARD_HEIGHT = 150;
 
 const BOTTOM_INSET_FOR_VIRTUAL_KEYBOARD = 0;
 
-export interface UseInsets {
+export type UseInsets = {
   top: Insets['top'];
   right: Insets['right'];
   bottom: Insets['bottom'];
   left: Insets['left'];
-}
+} | null;
 
-export const useInsets = (): UseInsets | null => {
-  const [insets, setInsets] = useState<UseInsets | null>(null);
+export const useInsets = (): UseInsets => {
+  const [insets, setInsets] = useState<UseInsets>(null);
 
   useIsomorphicLayoutEffect(() => {
     const handleBridgeEvent = (event: VKBridgeEvent<AnyReceiveMethodName>) => {

--- a/packages/react/src/hooks/useInsets.ts
+++ b/packages/react/src/hooks/useInsets.ts
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import vkBridge from '@vkontakte/vk-bridge';
+import type { VKBridgeEvent, AnyReceiveMethodName, Insets } from '@vkontakte/vk-bridge';
+import { useIsomorphicLayoutEffect } from '../lib/react';
+
+const VIRTUAL_KEYBOARD_HEIGHT = 150;
+
+const BOTTOM_INSET_FOR_VIRTUAL_KEYBOARD = 0;
+
+export interface UseInsets {
+  top: Insets['top'] | null;
+  right: Insets['right'] | null;
+  bottom: Insets['bottom'] | null;
+  left: Insets['left'] | null;
+}
+
+let initialState: UseInsets = {
+  bottom: null,
+  top: null,
+  left: null,
+  right: null,
+};
+
+export const useInsets = (): UseInsets => {
+  const [insets, setInsets] = useState<UseInsets>(initialState);
+
+  useIsomorphicLayoutEffect(() => {
+    const handleBridgeEvent = (event: VKBridgeEvent<AnyReceiveMethodName>) => {
+      const insets = resolveInsets(event);
+      if (insets) {
+        setInsets(insets);
+      }
+    };
+
+    vkBridge.subscribe(handleBridgeEvent);
+    return () => {
+      vkBridge.unsubscribe(handleBridgeEvent);
+    };
+  }, []);
+
+  return insets;
+};
+
+function resolveInsets(event: VKBridgeEvent<AnyReceiveMethodName>): UseInsets | null {
+  const { type, data } = event.detail;
+  switch (type) {
+    case 'VKWebAppUpdateInsets': // TODO [>=3]: it is legacy, remove it
+    case 'VKWebAppUpdateConfig':
+      if (!('insets' in data)) {
+        return null;
+      }
+      const { insets } = data;
+      if (insets) {
+        return {
+          ...insets,
+          bottom:
+            insets.bottom > VIRTUAL_KEYBOARD_HEIGHT
+              ? BOTTOM_INSET_FOR_VIRTUAL_KEYBOARD
+              : insets.bottom,
+        };
+      }
+  }
+  return null;
+}

--- a/packages/react/src/hooks/useInsets.ts
+++ b/packages/react/src/hooks/useInsets.ts
@@ -8,21 +8,14 @@ const VIRTUAL_KEYBOARD_HEIGHT = 150;
 const BOTTOM_INSET_FOR_VIRTUAL_KEYBOARD = 0;
 
 export interface UseInsets {
-  top: Insets['top'] | null;
-  right: Insets['right'] | null;
-  bottom: Insets['bottom'] | null;
-  left: Insets['left'] | null;
+  top: Insets['top'];
+  right: Insets['right'];
+  bottom: Insets['bottom'];
+  left: Insets['left'];
 }
 
-let initialState: UseInsets = {
-  bottom: null,
-  top: null,
-  left: null,
-  right: null,
-};
-
-export const useInsets = (): UseInsets => {
-  const [insets, setInsets] = useState<UseInsets>(initialState);
+export const useInsets = (): UseInsets | null => {
+  const [insets, setInsets] = useState<UseInsets | null>(null);
 
   useIsomorphicLayoutEffect(() => {
     const handleBridgeEvent = (event: VKBridgeEvent<AnyReceiveMethodName>) => {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,0 +1,5 @@
+export { type UseAdaptivity, useAdaptivity } from './hooks/useAdaptivity';
+export { type UseAppearance, useAppearance } from './hooks/useApperance';
+export { type UseInsets, useInsets } from './hooks/useInsets';
+
+export { runTapticImpactOccurred } from './functions/runTapticImpactOccurred';

--- a/packages/react/src/lib/react/index.ts
+++ b/packages/react/src/lib/react/index.ts
@@ -1,0 +1,1 @@
+export { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';

--- a/packages/react/src/lib/react/useIsomorphicLayoutEffect.ts
+++ b/packages/react/src/lib/react/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,4 @@
+import { useLayoutEffect, useEffect } from 'react';
+
+export const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,28 +15,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.21.4":
-  version: 7.21.4
-  resolution: "@babel/code-frame@npm:7.21.4"
-  dependencies:
-    "@babel/highlight": ^7.18.6
-  checksum: e5390e6ec1ac58dcef01d4f18eaf1fd2f1325528661ff6d4a5de8979588b9f5a8e852a54a91b923846f7a5c681b217f0a45c2524eb9560553160cd963b7d592c
-  languageName: node
-  linkType: hard
-
-"@babel/code-frame@npm:^7.22.5":
+"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/code-frame@npm:7.22.5"
   dependencies:
     "@babel/highlight": ^7.22.5
   checksum: cfe804f518f53faaf9a1d3e0f9f74127ab9a004912c3a16fda07fb6a633393ecb9918a053cb71804204c1b7ec3d49e1699604715e2cfb0c9f7bc4933d324ebb6
-  languageName: node
-  linkType: hard
-
-"@babel/compat-data@npm:^7.22.0":
-  version: 7.22.3
-  resolution: "@babel/compat-data@npm:7.22.3"
-  checksum: eb001646f41459f42ccb0d39ee8bb3c3c495bc297234817044c0002689c625e3159a6678c53fd31bd98cf21f31472b73506f350fc6906e3bdfa49cb706e2af8d
   languageName: node
   linkType: hard
 
@@ -47,30 +31,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.20.12":
-  version: 7.22.1
-  resolution: "@babel/core@npm:7.22.1"
-  dependencies:
-    "@ampproject/remapping": ^2.2.0
-    "@babel/code-frame": ^7.21.4
-    "@babel/generator": ^7.22.0
-    "@babel/helper-compilation-targets": ^7.22.1
-    "@babel/helper-module-transforms": ^7.22.1
-    "@babel/helpers": ^7.22.0
-    "@babel/parser": ^7.22.0
-    "@babel/template": ^7.21.9
-    "@babel/traverse": ^7.22.1
-    "@babel/types": ^7.22.0
-    convert-source-map: ^1.7.0
-    debug: ^4.1.0
-    gensync: ^1.0.0-beta.2
-    json5: ^2.2.2
-    semver: ^6.3.0
-  checksum: bbe45e791f223a7e692d2ea6597a73f48050abd24b119c85c48ac6504c30ce63343a2ea3f79b5847bf4b409ddd8a68b6cdc4f0272ded1d2ef6f6b1e9663432f0
-  languageName: node
-  linkType: hard
-
-"@babel/core@npm:^7.22.5":
+"@babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.20.12, @babel/core@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/core@npm:7.22.5"
   dependencies:
@@ -107,19 +68,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.22.0, @babel/generator@npm:^7.22.3, @babel/generator@npm:^7.7.2":
-  version: 7.22.3
-  resolution: "@babel/generator@npm:7.22.3"
-  dependencies:
-    "@babel/types": ^7.22.3
-    "@jridgewell/gen-mapping": ^0.3.2
-    "@jridgewell/trace-mapping": ^0.3.17
-    jsesc: ^2.5.1
-  checksum: ccb6426ca5b5a38f0d47a3ac9628e223d2aaaa489cbf90ffab41468795c22afe86855f68a58667f0f2673949f1810d4d5a57b826c17984eab3e28fdb34a909e6
-  languageName: node
-  linkType: hard
-
-"@babel/generator@npm:^7.22.5":
+"@babel/generator@npm:^7.22.5, @babel/generator@npm:^7.7.2":
   version: 7.22.5
   resolution: "@babel/generator@npm:7.22.5"
   dependencies:
@@ -128,21 +77,6 @@ __metadata:
     "@jridgewell/trace-mapping": ^0.3.17
     jsesc: ^2.5.1
   checksum: efa64da70ca88fe69f05520cf5feed6eba6d30a85d32237671488cc355fdc379fe2c3246382a861d49574c4c2f82a317584f8811e95eb024e365faff3232b49d
-  languageName: node
-  linkType: hard
-
-"@babel/helper-compilation-targets@npm:^7.22.1":
-  version: 7.22.1
-  resolution: "@babel/helper-compilation-targets@npm:7.22.1"
-  dependencies:
-    "@babel/compat-data": ^7.22.0
-    "@babel/helper-validator-option": ^7.21.0
-    browserslist: ^4.21.3
-    lru-cache: ^5.1.1
-    semver: ^6.3.0
-  peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: a686a01bd3288cf95ca26faa27958d34c04e2501c4b0858c3a6558776dec20317b5635f33d64c5a635b6fbdfe462a85c30d4bfa0ae7e7ffe3467e4d06442d7c8
   languageName: node
   linkType: hard
 
@@ -161,27 +95,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-environment-visitor@npm:^7.22.1":
-  version: 7.22.1
-  resolution: "@babel/helper-environment-visitor@npm:7.22.1"
-  checksum: a6b4bb5505453bff95518d361ac1de393f0029aeb8b690c70540f4317934c53c43cc4afcda8c752ffa8c272e63ed6b929a56eca28e4978424177b24238b21bf9
-  languageName: node
-  linkType: hard
-
 "@babel/helper-environment-visitor@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/helper-environment-visitor@npm:7.22.5"
   checksum: 248532077d732a34cd0844eb7b078ff917c3a8ec81a7f133593f71a860a582f05b60f818dc5049c2212e5baa12289c27889a4b81d56ef409b4863db49646c4b1
-  languageName: node
-  linkType: hard
-
-"@babel/helper-function-name@npm:^7.21.0":
-  version: 7.21.0
-  resolution: "@babel/helper-function-name@npm:7.21.0"
-  dependencies:
-    "@babel/template": ^7.20.7
-    "@babel/types": ^7.21.0
-  checksum: d63e63c3e0e3e8b3138fa47b0cd321148a300ef12b8ee951196994dcd2a492cc708aeda94c2c53759a5c9177fffaac0fd8778791286746f72a000976968daf4e
   languageName: node
   linkType: hard
 
@@ -195,15 +112,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-hoist-variables@npm:^7.18.6":
-  version: 7.18.6
-  resolution: "@babel/helper-hoist-variables@npm:7.18.6"
-  dependencies:
-    "@babel/types": ^7.18.6
-  checksum: fd9c35bb435fda802bf9ff7b6f2df06308a21277c6dec2120a35b09f9de68f68a33972e2c15505c1a1a04b36ec64c9ace97d4a9e26d6097b76b4396b7c5fa20f
-  languageName: node
-  linkType: hard
-
 "@babel/helper-hoist-variables@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/helper-hoist-variables@npm:7.22.5"
@@ -213,37 +121,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-imports@npm:^7.18.6, @babel/helper-module-imports@npm:^7.21.4":
-  version: 7.21.4
-  resolution: "@babel/helper-module-imports@npm:7.21.4"
-  dependencies:
-    "@babel/types": ^7.21.4
-  checksum: bd330a2edaafeb281fbcd9357652f8d2666502567c0aad71db926e8499c773c9ea9c10dfaae30122452940326d90c8caff5c649ed8e1bf15b23f858758d3abc6
-  languageName: node
-  linkType: hard
-
-"@babel/helper-module-imports@npm:^7.22.5":
+"@babel/helper-module-imports@npm:^7.18.6, @babel/helper-module-imports@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/helper-module-imports@npm:7.22.5"
   dependencies:
     "@babel/types": ^7.22.5
   checksum: 9ac2b0404fa38b80bdf2653fbeaf8e8a43ccb41bd505f9741d820ed95d3c4e037c62a1bcdcb6c9527d7798d2e595924c4d025daed73283badc180ada2c9c49ad
-  languageName: node
-  linkType: hard
-
-"@babel/helper-module-transforms@npm:^7.22.1":
-  version: 7.22.1
-  resolution: "@babel/helper-module-transforms@npm:7.22.1"
-  dependencies:
-    "@babel/helper-environment-visitor": ^7.22.1
-    "@babel/helper-module-imports": ^7.21.4
-    "@babel/helper-simple-access": ^7.21.5
-    "@babel/helper-split-export-declaration": ^7.18.6
-    "@babel/helper-validator-identifier": ^7.19.1
-    "@babel/template": ^7.21.9
-    "@babel/traverse": ^7.22.1
-    "@babel/types": ^7.22.0
-  checksum: dfa084211a93c9f0174ab07385fdbf7831bbf5c1ff3d4f984effc489f48670825ad8b817b9e9d2ec6492fde37ed6518c15944e9dd7a60b43a3d9874c9250f5f8
   languageName: node
   linkType: hard
 
@@ -270,30 +153,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-simple-access@npm:^7.21.5":
-  version: 7.21.5
-  resolution: "@babel/helper-simple-access@npm:7.21.5"
-  dependencies:
-    "@babel/types": ^7.21.5
-  checksum: ad212beaa24be3864c8c95bee02f840222457ccf5419991e2d3e3e39b0f75b77e7e857e0bf4ed428b1cd97acefc87f3831bdb0b9696d5ad0557421f398334fc3
-  languageName: node
-  linkType: hard
-
 "@babel/helper-simple-access@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/helper-simple-access@npm:7.22.5"
   dependencies:
     "@babel/types": ^7.22.5
   checksum: fe9686714caf7d70aedb46c3cce090f8b915b206e09225f1e4dbc416786c2fdbbee40b38b23c268b7ccef749dd2db35f255338fb4f2444429874d900dede5ad2
-  languageName: node
-  linkType: hard
-
-"@babel/helper-split-export-declaration@npm:^7.18.6":
-  version: 7.18.6
-  resolution: "@babel/helper-split-export-declaration@npm:7.18.6"
-  dependencies:
-    "@babel/types": ^7.18.6
-  checksum: c6d3dede53878f6be1d869e03e9ffbbb36f4897c7cc1527dc96c56d127d834ffe4520a6f7e467f5b6f3c2843ea0e81a7819d66ae02f707f6ac057f3d57943a2b
   languageName: node
   linkType: hard
 
@@ -313,17 +178,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-identifier@npm:^7.18.6, @babel/helper-validator-identifier@npm:^7.19.1, @babel/helper-validator-identifier@npm:^7.22.5":
+"@babel/helper-validator-identifier@npm:^7.19.1, @babel/helper-validator-identifier@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/helper-validator-identifier@npm:7.22.5"
   checksum: 7f0f30113474a28298c12161763b49de5018732290ca4de13cdaefd4fd0d635a6fe3f6686c37a02905fb1e64f21a5ee2b55140cf7b070e729f1bd66866506aea
-  languageName: node
-  linkType: hard
-
-"@babel/helper-validator-option@npm:^7.21.0":
-  version: 7.21.0
-  resolution: "@babel/helper-validator-option@npm:7.21.0"
-  checksum: 8ece4c78ffa5461fd8ab6b6e57cc51afad59df08192ed5d84b475af4a7193fc1cb794b59e3e7be64f3cdc4df7ac78bf3dbb20c129d7757ae078e6279ff8c2f07
   languageName: node
   linkType: hard
 
@@ -331,17 +189,6 @@ __metadata:
   version: 7.22.5
   resolution: "@babel/helper-validator-option@npm:7.22.5"
   checksum: bbeca8a85ee86990215c0424997438b388b8d642d69b9f86c375a174d3cdeb270efafd1ff128bc7a1d370923d13b6e45829ba8581c027620e83e3a80c5c414b3
-  languageName: node
-  linkType: hard
-
-"@babel/helpers@npm:^7.22.0":
-  version: 7.22.3
-  resolution: "@babel/helpers@npm:7.22.3"
-  dependencies:
-    "@babel/template": ^7.21.9
-    "@babel/traverse": ^7.22.1
-    "@babel/types": ^7.22.3
-  checksum: 385289ee8b87cf9af448bbb9fcf747f6e67600db5f7f64eb4ad97761ee387819bf2212b6a757008286c6bfacf4f3fc0b6de88686f2e517a70fb59996bdfbd1e9
   languageName: node
   linkType: hard
 
@@ -356,17 +203,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/highlight@npm:^7.18.6":
-  version: 7.18.6
-  resolution: "@babel/highlight@npm:7.18.6"
-  dependencies:
-    "@babel/helper-validator-identifier": ^7.18.6
-    chalk: ^2.0.0
-    js-tokens: ^4.0.0
-  checksum: 92d8ee61549de5ff5120e945e774728e5ccd57fd3b2ed6eace020ec744823d4a98e242be1453d21764a30a14769ecd62170fba28539b211799bbaf232bbb2789
-  languageName: node
-  linkType: hard
-
 "@babel/highlight@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/highlight@npm:7.22.5"
@@ -378,16 +214,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.21.9, @babel/parser@npm:^7.22.0, @babel/parser@npm:^7.22.4":
-  version: 7.22.4
-  resolution: "@babel/parser@npm:7.22.4"
-  bin:
-    parser: ./bin/babel-parser.js
-  checksum: 0ca6d3a2d9aae2504ba1bc494704b64a83140884f7379f609de69bd39b60adb58a4f8ec692fe53fef8657dd82705d01b7e6efb65e18296326bdd66f71d52d9a9
-  languageName: node
-  linkType: hard
-
-"@babel/parser@npm:^7.22.5":
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/parser@npm:7.22.5"
   bin:
@@ -559,18 +386,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/template@npm:^7.20.7, @babel/template@npm:^7.21.9, @babel/template@npm:^7.3.3":
-  version: 7.21.9
-  resolution: "@babel/template@npm:7.21.9"
-  dependencies:
-    "@babel/code-frame": ^7.21.4
-    "@babel/parser": ^7.21.9
-    "@babel/types": ^7.21.5
-  checksum: 6ec2c60d4d53b2a9230ab82c399ba6525df87e9a4e01e4b111e071cbad283b1362e7c99a1bc50027073f44f2de36a495a89c27112c4e7efe7ef9c8d9c84de2ec
-  languageName: node
-  linkType: hard
-
-"@babel/template@npm:^7.22.5":
+"@babel/template@npm:^7.22.5, @babel/template@npm:^7.3.3":
   version: 7.22.5
   resolution: "@babel/template@npm:7.22.5"
   dependencies:
@@ -581,25 +397,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.22.1, @babel/traverse@npm:^7.7.2":
-  version: 7.22.4
-  resolution: "@babel/traverse@npm:7.22.4"
-  dependencies:
-    "@babel/code-frame": ^7.21.4
-    "@babel/generator": ^7.22.3
-    "@babel/helper-environment-visitor": ^7.22.1
-    "@babel/helper-function-name": ^7.21.0
-    "@babel/helper-hoist-variables": ^7.18.6
-    "@babel/helper-split-export-declaration": ^7.18.6
-    "@babel/parser": ^7.22.4
-    "@babel/types": ^7.22.4
-    debug: ^4.1.0
-    globals: ^11.1.0
-  checksum: 9560ae22092d5a7c52849145dd3e5aed2ffb73d61255e70e19e3fbd06bcbafbbdecea28df40a42ee3b60b01e85a42224ec841df93e867547e329091cc2f2bb6f
-  languageName: node
-  linkType: hard
-
-"@babel/traverse@npm:^7.22.5":
+"@babel/traverse@npm:^7.22.5, @babel/traverse@npm:^7.7.2":
   version: 7.22.5
   resolution: "@babel/traverse@npm:7.22.5"
   dependencies:
@@ -617,7 +415,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.18.6, @babel/types@npm:^7.21.0, @babel/types@npm:^7.21.4, @babel/types@npm:^7.21.5, @babel/types@npm:^7.22.0, @babel/types@npm:^7.22.3, @babel/types@npm:^7.22.4, @babel/types@npm:^7.22.5, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.8.3":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.22.5, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.8.3":
   version: 7.22.5
   resolution: "@babel/types@npm:7.22.5"
   dependencies:
@@ -1388,14 +1186,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*":
-  version: 20.2.5
-  resolution: "@types/node@npm:20.2.5"
-  checksum: 38ce7c7e9d76880dc632f71d71e0d5914fcda9d5e9a7095d6c339abda55ca4affb0f2a882aeb29398f8e09d2c5151f0b6586c81c8ccdfe529c34b1ea3337425e
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^20.3.1":
+"@types/node@npm:*, @types/node@npm:^20.3.1":
   version: 20.3.1
   resolution: "@types/node@npm:20.3.1"
   checksum: 63a393ab6d947be17320817b35d7277ef03728e231558166ed07ee30b09fd7c08861be4d746f10fdc63ca7912e8cd023939d4eab887ff6580ff704ff24ed810c
@@ -1416,10 +1207,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/prop-types@npm:*":
+  version: 15.7.5
+  resolution: "@types/prop-types@npm:15.7.5"
+  checksum: 5b43b8b15415e1f298243165f1d44390403bb2bd42e662bca3b5b5633fdd39c938e91b7fce3a9483699db0f7a715d08cef220c121f723a634972fdf596aec980
+  languageName: node
+  linkType: hard
+
+"@types/react@npm:^18.2.13":
+  version: 18.2.13
+  resolution: "@types/react@npm:18.2.13"
+  dependencies:
+    "@types/prop-types": "*"
+    "@types/scheduler": "*"
+    csstype: ^3.0.2
+  checksum: f7c15f19c164a29262993ea2aae2085fa38cddd9b8359fd8fefabfced91010b515a3abe2042b2b7f2f86e6b38a25b191415aa9313a9027175e3a000883c858cc
+  languageName: node
+  linkType: hard
+
 "@types/resolve@npm:1.20.2":
   version: 1.20.2
   resolution: "@types/resolve@npm:1.20.2"
   checksum: 61c2cad2499ffc8eab36e3b773945d337d848d3ac6b7b0a87c805ba814bc838ef2f262fc0f109bfd8d2e0898ff8bd80ad1025f9ff64f1f71d3d4294c9f14e5f6
+  languageName: node
+  linkType: hard
+
+"@types/scheduler@npm:*":
+  version: 0.16.3
+  resolution: "@types/scheduler@npm:0.16.3"
+  checksum: 2b0aec39c24268e3ce938c5db2f2e77f5c3dd280e05c262d9c2fe7d890929e4632a6b8e94334017b66b45e4f92a5aa42ba3356640c2a1175fa37bef2f5200767
   languageName: node
   linkType: hard
 
@@ -1477,24 +1293,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:^5.50.0":
-  version: 5.59.9
-  resolution: "@typescript-eslint/parser@npm:5.59.9"
-  dependencies:
-    "@typescript-eslint/scope-manager": 5.59.9
-    "@typescript-eslint/types": 5.59.9
-    "@typescript-eslint/typescript-estree": 5.59.9
-    debug: ^4.3.4
-  peerDependencies:
-    eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 69b07d0a5bc6e1d24d23916c057ea9f2f53a0e7fb6dabadff92987c299640edee2c013fb93269322c7124e87b5c515529001397eae33006dfb40e1dcdf1902d7
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/parser@npm:^5.60.0":
+"@typescript-eslint/parser@npm:^5.50.0, @typescript-eslint/parser@npm:^5.60.0":
   version: 5.60.0
   resolution: "@typescript-eslint/parser@npm:5.60.0"
   dependencies:
@@ -1508,16 +1307,6 @@ __metadata:
     typescript:
       optional: true
   checksum: 94e7931a5b356b16638b281b8e1d661f8b1660f0c75a323537f68b311dae91b7a575a0a019d4ea05a79cc5d42b5cb41cc367205691cdfd292ef96a3b66b1e58b
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/scope-manager@npm:5.59.9":
-  version: 5.59.9
-  resolution: "@typescript-eslint/scope-manager@npm:5.59.9"
-  dependencies:
-    "@typescript-eslint/types": 5.59.9
-    "@typescript-eslint/visitor-keys": 5.59.9
-  checksum: 362c22662d844440a7e14223d8cc0722f77ff21ad8f78deb0ee3b3f21de01b8846bf25fbbf527544677e83d8ff48008b3f7d40b39ddec55994ea4a1863e9ec0a
   languageName: node
   linkType: hard
 
@@ -1548,35 +1337,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:5.59.9":
-  version: 5.59.9
-  resolution: "@typescript-eslint/types@npm:5.59.9"
-  checksum: 283f8fee1ee590eeccc2e0fcd3526c856c4b1e2841af2cdcd09eeac842a42cfb32f6bc8b40385380f3dbc3ee29da30f1819115eedf9e16f69ff5a160aeddd8fa
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/types@npm:5.60.0":
   version: 5.60.0
   resolution: "@typescript-eslint/types@npm:5.60.0"
   checksum: 48f29e5c084c5663cfed1a6c4458799a6690a213e7861a24501f9b96698ae59e89a1df1c77e481777e4da78f1b0a5573a549f7b8880e3f4071a7a8b686254db8
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/typescript-estree@npm:5.59.9":
-  version: 5.59.9
-  resolution: "@typescript-eslint/typescript-estree@npm:5.59.9"
-  dependencies:
-    "@typescript-eslint/types": 5.59.9
-    "@typescript-eslint/visitor-keys": 5.59.9
-    debug: ^4.3.4
-    globby: ^11.1.0
-    is-glob: ^4.0.3
-    semver: ^7.3.7
-    tsutils: ^3.21.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: c0c9b81f20a2a4337f07bc3ccdc9c1dabd765f59096255ed9a149e91e5c9517b25c2b6655f8f073807cfc13500c7451fbd9bb62e5e572c07cc07945ab042db89
   languageName: node
   linkType: hard
 
@@ -1613,16 +1377,6 @@ __metadata:
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
   checksum: cbe56567f0b53e24ad7ef7d2fb4cdc8596e2559c21ee639aa0560879b6216208550e51e9d8ae4b388ff21286809c6dc985cec66738294871051396a8ae5bccbc
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/visitor-keys@npm:5.59.9":
-  version: 5.59.9
-  resolution: "@typescript-eslint/visitor-keys@npm:5.59.9"
-  dependencies:
-    "@typescript-eslint/types": 5.59.9
-    eslint-visitor-keys: ^3.3.0
-  checksum: 2909ce761f7fe546592cd3c43e33263d8a5fa619375fd2fdffbc72ffc33e40d6feacafb28c79f36c638fcc2225048e7cc08c61cbac6ca63723dc68610d80e3e6
   languageName: node
   linkType: hard
 
@@ -1700,7 +1454,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vkontakte/vk-bridge@workspace:packages/core":
+"@vkontakte/vk-bridge-react@workspace:packages/react":
+  version: 0.0.0-use.local
+  resolution: "@vkontakte/vk-bridge-react@workspace:packages/react"
+  dependencies:
+    "@types/react": ^18.2.13
+    "@vkontakte/vk-bridge": "workspace:^"
+    eslint-plugin-react: ^7.32.2
+    eslint-plugin-react-hooks: ^4.6.0
+    react: ^18.2.0
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    "@vkontakte/vk-bridge": "workspace:^"
+    react: ^17.0.0 || ^18.1.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  languageName: unknown
+  linkType: soft
+
+"@vkontakte/vk-bridge@workspace:^, @vkontakte/vk-bridge@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@vkontakte/vk-bridge@workspace:packages/core"
   languageName: unknown
@@ -1910,7 +1683,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-includes@npm:^3.1.6":
+"array-includes@npm:^3.1.5, array-includes@npm:^3.1.6":
   version: 3.1.6
   resolution: "array-includes@npm:3.1.6"
   dependencies:
@@ -1951,6 +1724,19 @@ __metadata:
     es-abstract: ^1.20.4
     es-shim-unscopables: ^1.0.0
   checksum: 8c1c43a4995f12cf12523436da28515184c753807b3f0bc2ca6c075f71c470b099e2090cc67dba8e5280958fea401c1d0c59e1db0143272aef6cd1103921a987
+  languageName: node
+  linkType: hard
+
+"array.prototype.tosorted@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "array.prototype.tosorted@npm:1.1.1"
+  dependencies:
+    call-bind: ^1.0.2
+    define-properties: ^1.1.4
+    es-abstract: ^1.20.4
+    es-shim-unscopables: ^1.0.0
+    get-intrinsic: ^1.1.3
+  checksum: 7923324a67e70a2fc0a6e40237405d92395e45ebd76f5cb89c2a5cf1e66b47aca6baacd0cd628ffd88830b90d47fff268071493d09c9ae123645613dac2c2ca3
   languageName: node
   linkType: hard
 
@@ -2459,6 +2245,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"csstype@npm:^3.0.2":
+  version: 3.1.2
+  resolution: "csstype@npm:3.1.2"
+  checksum: e1a52e6c25c1314d6beef5168da704ab29c5186b877c07d822bd0806717d9a265e8493a2e35ca7e68d0f5d472d43fac1cdce70fd79fd0853dff81f3028d857b5
+  languageName: node
+  linkType: hard
+
 "date-fns@npm:^2.30.0":
   version: 2.30.0
   resolution: "date-fns@npm:2.30.0"
@@ -2840,6 +2633,40 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-react-hooks@npm:^4.6.0":
+  version: 4.6.0
+  resolution: "eslint-plugin-react-hooks@npm:4.6.0"
+  peerDependencies:
+    eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+  checksum: 23001801f14c1d16bf0a837ca7970d9dd94e7b560384b41db378b49b6e32dc43d6e2790de1bd737a652a86f81a08d6a91f402525061b47719328f586a57e86c3
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-react@npm:^7.32.2":
+  version: 7.32.2
+  resolution: "eslint-plugin-react@npm:7.32.2"
+  dependencies:
+    array-includes: ^3.1.6
+    array.prototype.flatmap: ^1.3.1
+    array.prototype.tosorted: ^1.1.1
+    doctrine: ^2.1.0
+    estraverse: ^5.3.0
+    jsx-ast-utils: ^2.4.1 || ^3.0.0
+    minimatch: ^3.1.2
+    object.entries: ^1.1.6
+    object.fromentries: ^2.0.6
+    object.hasown: ^1.1.2
+    object.values: ^1.1.6
+    prop-types: ^15.8.1
+    resolve: ^2.0.0-next.4
+    semver: ^6.3.0
+    string.prototype.matchall: ^4.0.8
+  peerDependencies:
+    eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+  checksum: 2232b3b8945aa50b7773919c15cd96892acf35d2f82503667a79e2f55def90f728ed4f0e496f0f157acbe1bd4397c5615b676ae7428fe84488a544ca53feb944
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-unicorn@npm:^47.0.0":
   version: 47.0.0
   resolution: "eslint-plugin-unicorn@npm:47.0.0"
@@ -2995,7 +2822,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"estraverse@npm:^5.1.0, estraverse@npm:^5.2.0":
+"estraverse@npm:^5.1.0, estraverse@npm:^5.2.0, estraverse@npm:^5.3.0":
   version: 5.3.0
   resolution: "estraverse@npm:5.3.0"
   checksum: 072780882dc8416ad144f8fe199628d2b3e7bbc9989d9ed43795d2c90309a2047e6bc5979d7e2322a341163d22cfad9e21f4110597fe487519697389497e4e2b
@@ -3730,7 +3557,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"internal-slot@npm:^1.0.5":
+"internal-slot@npm:^1.0.3, internal-slot@npm:^1.0.5":
   version: 1.0.5
   resolution: "internal-slot@npm:1.0.5"
   dependencies:
@@ -3801,7 +3628,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-core-module@npm:^2.11.0":
+"is-core-module@npm:^2.11.0, is-core-module@npm:^2.9.0":
   version: 2.12.1
   resolution: "is-core-module@npm:2.12.1"
   dependencies:
@@ -4496,7 +4323,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-tokens@npm:^4.0.0":
+"js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
   checksum: 8a95213a5a77deb6cbe94d86340e8d9ace2b93bc367790b260101d2f36a2eaf4e4e22d9fa9cf459b38af3a32fb4190e638024cf82ec95ef708680e405ea7cc78
@@ -4604,6 +4431,16 @@ __metadata:
     graceful-fs:
       optional: true
   checksum: 7af3b8e1ac8fe7f1eccc6263c6ca14e1966fcbc74b618d3c78a0a2075579487547b94f72b7a1114e844a1e15bb00d440e5d1720bfc4612d790a6f285d5ea8354
+  languageName: node
+  linkType: hard
+
+"jsx-ast-utils@npm:^2.4.1 || ^3.0.0":
+  version: 3.3.3
+  resolution: "jsx-ast-utils@npm:3.3.3"
+  dependencies:
+    array-includes: ^3.1.5
+    object.assign: ^4.1.3
+  checksum: a2ed78cac49a0f0c4be8b1eafe3c5257a1411341d8e7f1ac740debae003de04e5f6372bfcfbd9d082e954ffd99aac85bcda85b7c6bc11609992483f4cdc0f745
   languageName: node
   linkType: hard
 
@@ -4737,6 +4574,17 @@ __metadata:
     slice-ansi: ^4.0.0
     wrap-ansi: ^6.2.0
   checksum: ae2f85bbabc1906034154fb7d4c4477c79b3e703d22d78adee8b3862fa913942772e7fa11713e3d96fb46de4e3cabefbf5d0a544344f03b58d3c4bff52aa9eb2
+  languageName: node
+  linkType: hard
+
+"loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "loose-envify@npm:1.4.0"
+  dependencies:
+    js-tokens: ^3.0.0 || ^4.0.0
+  bin:
+    loose-envify: cli.js
+  checksum: 6517e24e0cad87ec9888f500c5b5947032cdfe6ef65e1c1936a0c48a524b81e65542c9c3edc91c97d5bddc806ee2a985dbc79be89215d613b1de5db6d1cfe6f4
   languageName: node
   linkType: hard
 
@@ -5150,7 +4998,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-assign@npm:^4.1.0":
+"object-assign@npm:^4.1.0, object-assign@npm:^4.1.1":
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
   checksum: fcc6e4ea8c7fe48abfbb552578b1c53e0d194086e2e6bbbf59e0a536381a292f39943c6e9628af05b5528aa5e3318bb30d6b2e53cadaf5b8fe9e12c4b69af23f
@@ -5171,7 +5019,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.assign@npm:^4.1.4":
+"object.assign@npm:^4.1.3, object.assign@npm:^4.1.4":
   version: 4.1.4
   resolution: "object.assign@npm:4.1.4"
   dependencies:
@@ -5180,6 +5028,38 @@ __metadata:
     has-symbols: ^1.0.3
     object-keys: ^1.1.1
   checksum: 76cab513a5999acbfe0ff355f15a6a125e71805fcf53de4e9d4e082e1989bdb81d1e329291e1e4e0ae7719f0e4ef80e88fb2d367ae60500d79d25a6224ac8864
+  languageName: node
+  linkType: hard
+
+"object.entries@npm:^1.1.6":
+  version: 1.1.6
+  resolution: "object.entries@npm:1.1.6"
+  dependencies:
+    call-bind: ^1.0.2
+    define-properties: ^1.1.4
+    es-abstract: ^1.20.4
+  checksum: 0f8c47517e6a9a980241eafe3b73de11e59511883173c2b93d67424a008e47e11b77c80e431ad1d8a806f6108b225a1cab9223e53e555776c612a24297117d28
+  languageName: node
+  linkType: hard
+
+"object.fromentries@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "object.fromentries@npm:2.0.6"
+  dependencies:
+    call-bind: ^1.0.2
+    define-properties: ^1.1.4
+    es-abstract: ^1.20.4
+  checksum: 453c6d694180c0c30df451b60eaf27a5b9bca3fb43c37908fd2b78af895803dc631242bcf05582173afa40d8d0e9c96e16e8874b39471aa53f3ac1f98a085d85
+  languageName: node
+  linkType: hard
+
+"object.hasown@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "object.hasown@npm:1.1.2"
+  dependencies:
+    define-properties: ^1.1.4
+    es-abstract: ^1.20.4
+  checksum: b936572536db0cdf38eb30afd2f1026a8b6f2cc5d2c4497c9d9bbb01eaf3e980dead4fd07580cfdd098e6383e5a9db8212d3ea0c6bdd2b5e68c60aa7e3b45566
   languageName: node
   linkType: hard
 
@@ -5471,6 +5351,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prop-types@npm:^15.8.1":
+  version: 15.8.1
+  resolution: "prop-types@npm:15.8.1"
+  dependencies:
+    loose-envify: ^1.4.0
+    object-assign: ^4.1.1
+    react-is: ^16.13.1
+  checksum: c056d3f1c057cb7ff8344c645450e14f088a915d078dcda795041765047fa080d38e5d626560ccaac94a4e16e3aa15f3557c1a9a8d1174530955e992c675e459
+  languageName: node
+  linkType: hard
+
 "punycode@npm:^2.1.0":
   version: 2.3.0
   resolution: "punycode@npm:2.3.0"
@@ -5501,10 +5392,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-is@npm:^16.13.1":
+  version: 16.13.1
+  resolution: "react-is@npm:16.13.1"
+  checksum: f7a19ac3496de32ca9ae12aa030f00f14a3d45374f1ceca0af707c831b2a6098ef0d6bdae51bd437b0a306d7f01d4677fcc8de7c0d331eb47ad0f46130e53c5f
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^18.0.0":
   version: 18.2.0
   resolution: "react-is@npm:18.2.0"
   checksum: e72d0ba81b5922759e4aff17e0252bd29988f9642ed817f56b25a3e217e13eea8a7f2322af99a06edb779da12d5d636e9fda473d620df9a3da0df2a74141d53e
+  languageName: node
+  linkType: hard
+
+"react@npm:^18.2.0":
+  version: 18.2.0
+  resolution: "react@npm:18.2.0"
+  dependencies:
+    loose-envify: ^1.1.0
+  checksum: 88e38092da8839b830cda6feef2e8505dec8ace60579e46aa5490fc3dc9bba0bd50336507dc166f43e3afc1c42939c09fe33b25fae889d6f402721dcd78fca1b
   languageName: node
   linkType: hard
 
@@ -5630,6 +5537,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve@npm:^2.0.0-next.4":
+  version: 2.0.0-next.4
+  resolution: "resolve@npm:2.0.0-next.4"
+  dependencies:
+    is-core-module: ^2.9.0
+    path-parse: ^1.0.7
+    supports-preserve-symlinks-flag: ^1.0.0
+  bin:
+    resolve: bin/resolve
+  checksum: c438ac9a650f2030fd074219d7f12ceb983b475da2d89ad3d6dd05fbf6b7a0a8cd37d4d10b43cb1f632bc19f22246ab7f36ebda54d84a29bfb2910a0680906d3
+  languageName: node
+  linkType: hard
+
 "resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.1#~builtin<compat/resolve>":
   version: 1.22.2
   resolution: "resolve@patch:resolve@npm%3A1.22.2#~builtin<compat/resolve>::version=1.22.2&hash=c3c19d"
@@ -5640,6 +5560,19 @@ __metadata:
   bin:
     resolve: bin/resolve
   checksum: 66cc788f13b8398de18eb4abb3aed90435c84bb8935953feafcf7231ba4cd191b2c10b4a87b1e9681afc34fb138c705f91f7330ff90bfa36f457e5584076a2b8
+  languageName: node
+  linkType: hard
+
+"resolve@patch:resolve@^2.0.0-next.4#~builtin<compat/resolve>":
+  version: 2.0.0-next.4
+  resolution: "resolve@patch:resolve@npm%3A2.0.0-next.4#~builtin<compat/resolve>::version=2.0.0-next.4&hash=c3c19d"
+  dependencies:
+    is-core-module: ^2.9.0
+    path-parse: ^1.0.7
+    supports-preserve-symlinks-flag: ^1.0.0
+  bin:
+    resolve: bin/resolve
+  checksum: 4bf9f4f8a458607af90518ff73c67a4bc1a38b5a23fef2bb0ccbd45e8be89820a1639b637b0ba377eb2be9eedfb1739a84cde24fe4cd670c8207d8fea922b011
   languageName: node
   linkType: hard
 
@@ -6098,6 +6031,22 @@ __metadata:
     emoji-regex: ^9.2.2
     strip-ansi: ^7.0.1
   checksum: 7369deaa29f21dda9a438686154b62c2c5f661f8dda60449088f9f980196f7908fc39fdd1803e3e01541970287cf5deae336798337e9319a7055af89dafa7193
+  languageName: node
+  linkType: hard
+
+"string.prototype.matchall@npm:^4.0.8":
+  version: 4.0.8
+  resolution: "string.prototype.matchall@npm:4.0.8"
+  dependencies:
+    call-bind: ^1.0.2
+    define-properties: ^1.1.4
+    es-abstract: ^1.20.4
+    get-intrinsic: ^1.1.3
+    has-symbols: ^1.0.3
+    internal-slot: ^1.0.3
+    regexp.prototype.flags: ^1.4.3
+    side-channel: ^1.0.4
+  checksum: 952da3a818de42ad1c10b576140a5e05b4de7b34b8d9dbf00c3ac8c1293e9c0f533613a39c5cda53e0a8221f2e710bc2150e730b1c2278d60004a8a35726efb6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Выпускаем новый пакет `@vkontakte/vk-bridge-react` версии **1.0.0**.

Пакет реализует доступ к данным методов из [@vkontakte/vk-bridge](https://www.npmjs.com/package/@vkontakte/vk-bridge) через React-хуки. Подробнее в [документация пакета](https://github.com/VKCOM/vk-bridge/blob/imirdzhamolov/vk-bridge-react/release_1.0.0/packages/react/README.md).

## Тест

Были выпущены несколько бета-версий, последняя в NPM [@vkontakte/vk-bridge-react@1.0.0-beta.4](https://www.npmjs.com/package/@vkontakte/vk-bridge-react/v/1.0.0-beta.4). Пакет тестировался в репе https://github.com/VKCOM/create-vk-mini-app.

## Workflows

Расширил список пакетов в `.github/workflows/publish.yml` и `.github/workflows/publish_prerelease.yml` пунктом `@vkontakte/vk-bridge-react`.

Выпуск релизов ничем не отличается от пакета `@vkontakte/vk-bridge`.