### PR TITLE
fix(@vkontakte/vk-bridge-react): rm check if adaptivity is exist

### DIFF
--- a/packages/react/src/hooks/useAdaptivity.ts
+++ b/packages/react/src/hooks/useAdaptivity.ts
@@ -26,7 +26,7 @@ export const useAdaptivity = (): UseAdaptivity => {
 
   useIsomorphicLayoutEffect(() => {
     const updateAdaptivity = (data: ParentConfigData) => {
-      if (!('adaptivity' in data) || !('viewport_width' in data) || !('viewport_height' in data)) {
+      if (!('viewport_width' in data) || !('viewport_height' in data)) {
         return;
       }
 


### PR DESCRIPTION
- fix #480

Because adaptivity can be `undefined`. We shouldn't check if is exist.