### PR TITLE
bump(@vkontakte/vk-bridge-react): from 1.0.0 to 1.0.1

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vkontakte/vk-bridge-react",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "React hooks for VK Bridge",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/react/src/hooks/useAdaptivity.ts
+++ b/packages/react/src/hooks/useAdaptivity.ts
@@ -26,7 +26,7 @@ export const useAdaptivity = (): UseAdaptivity => {
 
   useIsomorphicLayoutEffect(() => {
     const updateAdaptivity = (data: ParentConfigData) => {
-      if (!('adaptivity' in data) || !('viewport_width' in data) || !('viewport_height' in data)) {
+      if (!('viewport_width' in data) || !('viewport_height' in data)) {
         return;
       }
 


### PR DESCRIPTION
# Chaneglog

- `useAdaptivity()`: now it's returning correct value for `viewportWidth` and `viewportHeight` (#481)