### PR TITLE
build(fix): rm flag -p from build workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "@vk-bridge/monorepo",
   "version": "0.0.0",
   "scripts": {
-    "build": "yarn workspaces foreach -pt run build",
+    "build": "yarn workspaces foreach -t run build",
     "build:clean": "rimraf packages/**/dist packages/**/node_modules/.cache",
     "test": "yarn build && jest",
     "test:ci": "jest --ci --silent --outputFile ./test-results.json --json",


### PR DESCRIPTION
> Дока про флаги в Yarn https://yarnpkg.com/cli/workspaces/foreach#details

Флаг `--parallel` конфликтует с `--topology`, который должен собирать воркспейсы в определенном порядке.

Воспроизводится при паблише ветки [syarkin/vk-bridge/release_2.12.0](https://github.com/VKCOM/vk-bridge/tree/syarkin/vk-bridge/release_2.12.0) (см. [результат паблиша](https://github.com/VKCOM/vk-bridge/actions/runs/6887978987/job/18736107728)).