### PR TITLE
Syarkin/vk bridge/release 2.12.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vkontakte/vk-bridge",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "Connects a Mini App with VK client",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vkontakte/vk-bridge",
-  "version": "2.11.2",
+  "version": "2.12.0",
   "description": "Connects a Mini App with VK client",
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
Пришлось апать еще и патч, так как ранее 3 месяца назад, по ошибке была апнута 2.12.0, а потом вовзвращена 2.11.0 и от нее пашли патчи.
При попытка поднять до 2.12.0 приходило ошибка от нпм что версия уже существует, по этому был апнут еще патч