### PR TITLE
Fix Typing success response method VKWebAppShare

### DIFF
--- a/packages/core/src/types/data.ts
+++ b/packages/core/src/types/data.ts
@@ -1098,6 +1098,10 @@ export type AddToProfileResponse = {
   visibility: 'all' | 'friends' | 'best_friends';
 };
 
+export type AppShareResponse = {
+  result: LinkShareResult[];
+};
+
 /**
  * Map of types of request props of VK Bridge methods
  */
@@ -1251,7 +1255,7 @@ export type ReceiveDataMap = {
   VKWebAppSendToClient: { result: true };
   VKWebAppSetLocation: { result: true };
   VKWebAppSetViewSettings: { result: true };
-  VKWebAppShare: LinkShareResult[];
+  VKWebAppShare: AppShareResponse;
   VKWebAppShowCommunityWidgetPreviewBox: { result: true };
   VKWebAppShowImages: { result: true };
   VKWebAppShowInviteBox: { success: true };


### PR DESCRIPTION
- close #554

# Описание проблемы
Проблема была в неверной типизации ответа метода VKWebAppShare; 

# Описание решения
Добавлена нужная типизация для ответа АПИ с вложенностью { result: [] }

# Способ проверки с шагами
Проверить типизацию возвращаемых параметров, там будет { result: LinkShareResult[] }
