### PR TITLE
mark VKWebAppGetFriends as supported on mobile web

### DIFF
--- a/packages/core/src/bridge.ts
+++ b/packages/core/src/bridge.ts
@@ -103,6 +103,7 @@ export const DESKTOP_METHODS = [
   'VKWebAppTranslate',
   'VKWebAppRecommend',
   'VKWebAppAddToProfile',
+  'VKWebAppGetFriends',
 
   // Desktop web specific events
   ...(IS_DESKTOP_VK
@@ -110,7 +111,6 @@ export const DESKTOP_METHODS = [
         'VKWebAppResizeWindow',
         'VKWebAppAddToMenu',
         'VKWebAppShowInstallPushBox',
-        'VKWebAppGetFriends',
         'VKWebAppShowCommunityWidgetPreviewBox',
         'VKWebAppCallStart',
         'VKWebAppCallJoin',


### PR DESCRIPTION
## Описание проблемы

На m.vk.com была добавлена поддержка метода `VKWebAppGetFriends`, но в `vk-bridge` он помечен как web-only

## Описание решения

Отметил `VKWebAppGetFriends` как поддерживаемый на m.vk.com чтобы метод `bridge.supports()` возвращал `true`
