### PR TITLE
ci: update upload-artifact and download-artifact actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,7 +24,7 @@ jobs:
         run: yarn run lint:ci
 
       - name: Upload lint scripts artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: lint-scripts-output
@@ -47,7 +47,7 @@ jobs:
         run: yarn run test:ci
 
       - name: Upload test artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-output
@@ -62,12 +62,12 @@ jobs:
     name: Report CI results
     steps:
       - name: Download lint scripts artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: lint-scripts-output
 
       - name: Download test artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: test-output
 


### PR DESCRIPTION
## Описание проблемы

`actions/upload-artifact@v3` и `actions/upload-artifact@v3` [устарели](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) из-за чего падают пайпы в ПРах

## Описание решения

Обновил экшены до v4
