### PR TITLE
Add bdate_visibility field to GetUserInfo response type

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v2.15.5
+
+- Добавили недостающее поле `bdate_visibility` в ответ метода `VKWebAppGetUserInfo`
+
 ## v2.15.4
 
 - Исправили лишние ворнинги в консоли при вызове `bridge.supportsAsync`

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v2.15.5
 
-- Добавили недостающее поле `bdate_visibility` в ответ метода `VKWebAppGetUserInfo`
+- Добавили недостающие поля `bdate_visibility`, `can_access_closed`, `is_closed` в ответ метода `VKWebAppGetUserInfo`
 
 ## v2.15.4
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vkontakte/vk-bridge",
-  "version": "2.15.4",
+  "version": "2.15.5",
   "description": "Connects a Mini App with VK client",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/core/src/types/data.ts
+++ b/packages/core/src/types/data.ts
@@ -77,6 +77,9 @@ export type UserInfo = {
    * the field is not in the response.
    */
   bdate?: string;
+  /** Visibility of Date of birth: 0 - hidden, 1 - entire date of birth is visible,
+   * 2 - day and month are visible */
+  bdate_visibility: 0 | 1 | 2;
   /**
    * URL of the square user's photo with 100px width.
    * https://vk.com/images/camera_100.png will be returned if the photo

--- a/packages/core/src/types/data.ts
+++ b/packages/core/src/types/data.ts
@@ -77,9 +77,14 @@ export type UserInfo = {
    * the field is not in the response.
    */
   bdate?: string;
-  /** Visibility of Date of birth: 0 - hidden, 1 - entire date of birth is visible,
+  /**
+   * Visibility of Date of birth: 0 - hidden, 1 - entire date of birth is visible,
    * 2 - day and month are visible */
   bdate_visibility: 0 | 1 | 2;
+  /** Can see a private user profile */
+  can_access_closed: boolean;
+  /** Is user profile closed */
+  is_closed: boolean;
   /**
    * URL of the square user's photo with 100px width.
    * https://vk.com/images/camera_100.png will be returned if the photo


### PR DESCRIPTION
<!--
Если ваш pull request еще не готов до конца, отметьте его как draft.
(см. https://github.blog/2019-02-14-introducing-draft-pull-requests/)

Чек лист для отправки нового pull request в репозиторий vk-bridge:
1) 👷‍♀️ Создавайте небольшие PR. Один PR - одна проблема. Чем меньше изменений, тем проще нам будет его рассмотреть.
2) ✅ Проверьте, что ваши изменения прошли проверки линтерами.
3) 📝 В commit messages указывайте, какую именно пользу приносят ваши изменения.
4) ⚠️ Убедитесь, что ваши изменения не сломают обратную совместимость текущего функционала.
5) 🧑‍💻 Протестируйте ваши изменения на поддерживаемых библиотекой платформах (IOS/Android/Web/MobleWeb).

Если этот PR закрывает Issue, то укажите ссылку на него. Используйте доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests).

Пример:
- close #123 
-->

## Описание проблемы
В типах ответа события GetUserInfo не было поля bdate_visibility
<!--
Проблема должна быть описана понятно и полностью, по возможности максимально коротко.
Для бага - дополнительно приведите описание окружения и шагов воспроизведения.
Если по данной проблеме создано issue, то добавьте ссылки.

Пример:
- related to #123
-->

## Описание решения
В тип ответа события GetUserInfo добавлено поле bdate_visibility
<!--
Напишите подробности о том, что делает PR.
-->


## Способ проверки с шагами
Установить версию vk bridge из ветки, проверить работу автокомплита и проверки типов в ide
<!--
Опишите то, как тестировался данный pull request.
По возможности приведите алгоритм действий, расписанный по шагам.
-->

## Обратная совместимость
Совместимо со старыми версиями
<!--
Если ваш pull request изменяет поведение текущей реализации, то подробно опишите результат до/после.
-->


<!--
Спасибо за то, что помогаете нам стать лучше!
-->
