### PR TITLE
MA-21435: fix userInfo type

### DIFF
--- a/packages/core/src/types/data.ts
+++ b/packages/core/src/types/data.ts
@@ -97,6 +97,16 @@ export type UserInfo = {
   photo_max_orig?: string;
   /** User's timezone */
   timezone?: number;
+  /** Bdate visibility */
+  bdate_visibility: 0 | 1 | 2;
+  /** Can see a private user profile */
+  can_access_closed: boolean;
+  /** Is user profile closed */
+  is_closed: boolean;
+  /**
+   * URL of the square user's photo with maximum size.
+   */
+  photo_base?: string;
 };
 
 /**


### PR DESCRIPTION
<!--
Если ваш pull request еще не готов до конца, отметьте его как draft.
(см. https://github.blog/2019-02-14-introducing-draft-pull-requests/)

Чек лист для отправки нового pull request в репозиторий vk-bridge:
1) 👷‍♀️ Создавайте небольшие PR. Один PR - одна проблема. Чем меньше изменений, тем проще нам будет его рассмотреть.
2) ✅ Проверьте, что ваши изменения прошли проверки линтерами.
3) 📝 В commit messages указывайте, какую именно пользу приносят ваши изменения.
4) ⚠️ Убедитесь, что ваши изменения не сломают обратную совместимость текущего функционала.
5) 🧑‍💻 Протестируйте ваши изменения на поддерживаемых библиотекой платформах (IOS/Android/Web/MobleWeb).

Если этот PR закрывает Issue, то укажите ссылку на него. Используйте доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests).

Пример:
- close #123 
-->

## Описание проблемы

тип UserInfo не соответствует ответу VkWebAppGetUserIfno

## Описание решения

Добавляю поля
bdate_visibility
can_access_closed
is_closed
photo_base - не приходит на мобильных клиентах


## Обратная совместимость

Не ломается

## Скриншоты

![image](https://github.com/user-attachments/assets/6857697d-9eb4-4569-ab4e-9e829e84593a)


<!--
Спасибо за то, что помогаете нам стать лучше!
-->
